### PR TITLE
Mud 188/address resolver

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -10,6 +10,7 @@
     "no-complex-fallback": "off",
     "reason-string": "off",
     "func-visibility": ["warn", {"ignoreConstructors": true}],
-    "constructor-syntax": "warn"
+    "constructor-syntax": "warn",
+    "named-parameters-mapping": "error"
   }
 }

--- a/contracts/IZNSAddressResolver.sol
+++ b/contracts/IZNSAddressResolver.sol
@@ -1,14 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.18;
 
-interface IZNSAddressResolver{
-    /**
-     * @dev Emit when ownership of a domain is modified
-     * @param newAddress The new domain owner
-     * @param domainNameHash The identifying hash of a domain's name
-     */
-    event AddressSet(bytes32 indexed domainNameHash, address indexed newAddress);
+interface IZNSAddressResolver {
+  /**
+   * @dev Emit when ownership of a domain is modified
+   * @param newAddress The new domain owner
+   * @param domainNameHash The identifying hash of a domain's name
+   */
+  event AddressSet(bytes32 indexed domainNameHash, address indexed newAddress);
 
-    function getAddress(bytes32 domainNameHash) external view returns(address);
-    function setAddress(bytes32 domainNameHash, address newAddress) external;
+  function supportsInterface(bytes4 interfaceId) external view returns (bool);
+
+  function getAddress(bytes32 domainNameHash) external view returns (address);
+
+  function setAddress(bytes32 domainNameHash, address newAddress) external;
 }

--- a/contracts/IZNSAddressResolver.sol
+++ b/contracts/IZNSAddressResolver.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+interface IZNSAddressResolver{
+    /**
+     * @dev Emit when ownership of a domain is modified
+     * @param newAddress The new domain owner
+     * @param domainNameHash The identifying hash of a domain's name
+     */
+    event AddressSet(bytes32 indexed domainNameHash, address indexed newAddress);
+
+    function getAddress(bytes32 domainNameHash) external view returns(address);
+    function setAddress(bytes32 domainNameHash, address newAddress) external;
+}

--- a/contracts/IZNSResolver.sol
+++ b/contracts/IZNSResolver.sol
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
-
-interface IZNSResolver {
-  // TODO
-}

--- a/contracts/ZNSAddressResolver.sol
+++ b/contracts/ZNSAddressResolver.sol
@@ -7,7 +7,7 @@ import "./IZNSRegistry.sol";
 
 contract ZNSAddressResolver is ERC165, IZNSAddressResolver {
   IZNSRegistry public registry; /// @notice IZNSRegistry
-  mapping(bytes32 => address) private addressOf; /// @notice mapping of domain hash to address
+  mapping(bytes32 domainNameHash => address resolvedAddress) private addressOf; /// @notice mapping of domain hash to address
 
   constructor(IZNSRegistry _registry) {
     registry = _registry;
@@ -43,6 +43,8 @@ contract ZNSAddressResolver is ERC165, IZNSAddressResolver {
     bytes32 domainNameHash,
     address newAddress
   ) external onlyOwnerOrOperator(domainNameHash) {
+    require(newAddress != address(0), "ZNS: Cant set address to 0");
+
     addressOf[domainNameHash] = newAddress;
 
     emit AddressSet(domainNameHash, newAddress);

--- a/contracts/ZNSAddressResolver.sol
+++ b/contracts/ZNSAddressResolver.sol
@@ -25,6 +25,9 @@ contract ZNSAddressResolver is ERC165, IZNSAddressResolver {
    * @dev Revert if `msg.sender` is not the owner or an operator allowed by the owner
    * @param domainNameHash The identifying hash of a domain's name
    */
+  // TODO:  Remove this when doing access control.
+  //        A function like that can be created in Registry, but think
+  //        deeper if we want this to be for owner in Registry or owner of the Token in DomainToken!
   modifier onlyOwnerOrOperator(bytes32 domainNameHash) {
     address owner = registry.getDomainRecord(domainNameHash).owner;
     require(

--- a/contracts/ZNSAddressResolver.sol
+++ b/contracts/ZNSAddressResolver.sol
@@ -6,8 +6,16 @@ import "./IZNSAddressResolver.sol";
 import "./IZNSRegistry.sol";
 
 contract ZNSAddressResolver is ERC165, IZNSAddressResolver {
-  IZNSRegistry public registry; /// @notice IZNSRegistry
-  mapping(bytes32 domainNameHash => address resolvedAddress) private addressOf; /// @notice mapping of domain hash to address
+  /**
+   * @notice Address of the ZNSRegistry contract that holds all crucial data
+   *         for every domain in the system
+  */
+  IZNSRegistry public registry;
+  /**
+   * @notice Mapping of domain hash to address used to bind domains
+   *         to Ethereum wallets or contracts registered in ZNS
+  */
+  mapping(bytes32 domainNameHash => address resolvedAddress) private addressOf;
 
   constructor(IZNSRegistry _registry) {
     registry = _registry;

--- a/contracts/ZNSAddressResolver.sol
+++ b/contracts/ZNSAddressResolver.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import "./IZNSAddressResolver.sol";
+import "./IZNSRegistry.sol";
+
+contract ZNSAddressResolver is IZNSAddressResolver {
+  bytes4 internal resolverInterfaceId; /// @notice erc-165 interface ID, calculated in constructor
+  IZNSRegistry public registry; /// @notice IZNSRegistry
+  mapping(bytes32 => address) private addressOf; /// @notice mapping of domain hash to address
+
+  constructor(IZNSRegistry _registry) {
+    registry = _registry;
+    resolverInterfaceId = calculateSelector();
+  }
+
+  /**
+   * @dev Revert if `msg.sender` is not the owner or an operator allowed by the owner
+   * @param domainNameHash The identifying hash of a domain's name
+   */
+  modifier onlyOwnerOrOperator(bytes32 domainNameHash) {
+    address owner = registry.getDomainRecord(domainNameHash).owner;
+    require(
+      msg.sender == owner || registry.isAllowedOperator(owner, msg.sender),
+      "ZNS: Not allowed"
+    );
+    _;
+  }
+
+  /**
+   * @dev Resolves address given domain name hash
+   * @param domainNameHash The identifying hash of a domain's name
+   */
+  function getAddress(bytes32 domainNameHash) external view returns (address) {
+    return addressOf[domainNameHash];
+  }
+
+  /**
+   * @dev Sets the address of a domain name hash, only registry
+   * @param domainNameHash The identifying hash of a domain's name
+   * @param newAddress The new domain owner
+   */
+  function setAddress(
+    bytes32 domainNameHash,
+    address newAddress
+  ) external onlyOwnerOrOperator(domainNameHash) {
+    addressOf[domainNameHash] = newAddress;
+
+    emit AddressSet(domainNameHash, newAddress);
+  }
+
+  /**
+   * @dev ERC-165 check for implementation identifier
+   * @param interfaceId ID to check
+   */
+  function supportsInterface(bytes4 interfaceId) external view returns (bool) {
+    return interfaceId == resolverInterfaceId;
+  }
+
+  /**
+   * @dev Calculate the erc165 interfaceID
+   * XOR of the function selectors, which are the first 4 bytes of the keccak256 hash of the function signatures
+   */
+  function calculateSelector() public pure returns (bytes4) {
+    bytes4 getAddressSelector = bytes4(keccak256("getAddress(bytes32)"));
+    bytes4 setAddressSelector = bytes4(
+      keccak256("setAddress(bytes32,address)")
+    );
+
+    return getAddressSelector ^ setAddressSelector;
+  }
+}

--- a/contracts/ZNSRegistry.sol
+++ b/contracts/ZNSRegistry.sol
@@ -10,13 +10,13 @@ contract ZNSRegistry is IZNSRegistry, ERC1967UpgradeUpgradeable {
    * @dev Mapping `domainNameHash` to `DomainRecord` struct to hold information
    * about each domain
    */
-  mapping(bytes32 => DomainRecord) private records;
+  mapping(bytes32 domainHash => DomainRecord domainRecord) private records;
 
   /**
    * @dev Mapping of `owner` => `operator` => `bool` to show accounts that
    * are or aren't allowed access to domains that `owner` has access to.
    */
-  mapping(address => mapping(address => bool)) private operators;
+  mapping(address owner => mapping(address operator => bool)) private operators;
 
   /**
    * @dev Revert if `msg.sender` is not the owner or an operator allowed by the owner

--- a/package.json
+++ b/package.json
@@ -56,5 +56,8 @@
   },
   "dependencies": {
     "dotenv": "16.0.3"
+  },
+  "resolutions": {
+    "@solidity-parser/parser": "0.16.0"
   }
 }

--- a/test/ZNSAddressResolver.test.ts
+++ b/test/ZNSAddressResolver.test.ts
@@ -1,83 +1,126 @@
-const { expect } = require("chai");
-import * as hre from "hardhat";
-import { ZNSAddressResolver, ZNSAddressResolver__factory } from "../typechain";
-import { ZNSRegistry, ZNSRegistry__factory } from "../typechain";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import * as hre from 'hardhat';
+import {
+  ZNSRegistry,
+  ZNSRegistry__factory,
+  ZNSAddressResolver,
+  ZNSAddressResolver__factory,
+  IERC165__factory, ERC165__factory,
+} from '../typechain';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { expect } = require('chai');
 /**
- * TODO the registry should have a function for checking isOwnerOrOperator, 
+ * TODO the registry should have a function for checking isOwnerOrOperator,
  * so that the AddressResolver can implement a single call in its modifier.
- * 
+ *
  * Consider moving these tests to ZNSRegistry since they deploy a registry.
  */
-describe("ZNSAddressResolver", function () {
-    let deployer: SignerWithAddress;
-    let znsAddressResolver: ZNSAddressResolver;
-    let znsRegistry: ZNSRegistry;
-    let owner: SignerWithAddress;
-    let addr1: SignerWithAddress;
-    let operator: SignerWithAddress;
-    const rootDomainHash = hre.ethers.constants.HashZero;
-    const wilderLabel = hre.ethers.utils.id("wilder");
-    const wilderDomainNameHash = hre.ethers.utils.solidityKeccak256(["bytes32", "bytes32"], [rootDomainHash, wilderLabel]);
+describe('ZNSAddressResolver', () => {
+  let deployer : SignerWithAddress;
+  let znsAddressResolver : ZNSAddressResolver;
+  let znsRegistry : ZNSRegistry;
+  let owner : SignerWithAddress;
+  let addr1 : SignerWithAddress;
+  let operator : SignerWithAddress;
+  const rootDomainHash = hre.ethers.constants.HashZero;
+  const wilderLabel = hre.ethers.utils.id('wilder');
+  const wilderDomainNameHash = hre.ethers.utils
+    .solidityKeccak256(
+      ['bytes32', 'bytes32'],
+      [rootDomainHash, wilderLabel]
+    );
 
-    beforeEach(async function () {
-        [owner, addr1] = await hre.ethers.getSigners();
-        [deployer, operator] = await hre.ethers.getSigners();
+  beforeEach(async () => {
+    [owner, addr1] = await hre.ethers.getSigners();
+    [deployer, operator] = await hre.ethers.getSigners();
 
-        const znsAddressResolverFactory = new ZNSAddressResolver__factory(deployer);
-        const znsRegistryFactory = new ZNSRegistry__factory(deployer);
+    const znsAddressResolverFactory = new ZNSAddressResolver__factory(deployer);
+    const znsRegistryFactory = new ZNSRegistry__factory(deployer);
 
-        znsRegistry = await znsRegistryFactory.deploy();
-        znsAddressResolver = await znsAddressResolverFactory.deploy(znsRegistry.address);
+    znsRegistry = await znsRegistryFactory.deploy();
+    znsAddressResolver = await znsAddressResolverFactory.deploy(znsRegistry.address);
 
-        //Initialize registry and domain
-        await znsRegistry.connect(deployer).initialize(deployer.address);
-        await znsRegistry.connect(deployer).setSubdomainRecord(rootDomainHash, wilderLabel, deployer.address, znsAddressResolver.address);
-    });
+    // Initialize registry and domain
+    await znsRegistry.connect(deployer).initialize(deployer.address);
+    await znsRegistry.connect(deployer)
+      .setSubdomainRecord(
+        rootDomainHash,
+        wilderLabel,
+        deployer.address,
+        znsAddressResolver.address
+      );
+  });
 
-    it("Should get the AddressResolver", async () => { // Copy of registry tests
-        // The domain exists
-        const existResolver = await znsRegistry.getDomainResolver(wilderDomainNameHash);
-        expect(existResolver).to.eq(znsAddressResolver.address);
+  it('Should get the AddressResolver', async () => { // Copy of registry tests
+    // The domain exists
+    const existResolver = await znsRegistry.getDomainResolver(wilderDomainNameHash);
+    expect(existResolver).to.eq(znsAddressResolver.address);
 
-        // The domain does not exist
-        const someDomainHash = hre.ethers.utils.id("random-record");
-        const notExistResolver = await znsRegistry.getDomainResolver(someDomainHash);
-        expect(notExistResolver).to.eq(hre.ethers.constants.AddressZero);
-    });
+    // The domain does not exist
+    const someDomainHash = hre.ethers.utils.id('random-record');
+    const notExistResolver = await znsRegistry.getDomainResolver(someDomainHash);
+    expect(notExistResolver).to.eq(hre.ethers.constants.AddressZero);
+  });
 
-    it("Should have registry address correctly set", async function () {
-        expect(await znsAddressResolver.registry()).to.equal(znsRegistry.address);
-    });
+  it('Should have registry address correctly set', async () => {
+    expect(await znsAddressResolver.registry()).to.equal(znsRegistry.address);
+  });
 
-    it("Should not allow non-owner address to setAddress", async function () {
-        await expect(znsAddressResolver.connect(addr1).setAddress(wilderDomainNameHash, addr1.address)).to.be.revertedWith("ZNS: Not allowed");
-    });
+  it('Should not allow non-owner address to setAddress', async () => {
+    await expect(
+      znsAddressResolver.connect(addr1).setAddress(wilderDomainNameHash, addr1.address)
+    ).to.be.revertedWith('ZNS: Not allowed');
+  });
 
-    it("Should allow owner to setAddress and emit event", async function () {
-        await expect(znsAddressResolver.connect(owner).setAddress(wilderDomainNameHash, addr1.address)).to.emit(znsAddressResolver, "AddressSet").withArgs(wilderDomainNameHash, addr1.address);
-    });
+  it('Should allow owner to setAddress and emit event', async () => {
+    await expect(
+      znsAddressResolver.connect(owner)
+        .setAddress(wilderDomainNameHash, addr1.address)
+    )
+      .to.emit(znsAddressResolver, 'AddressSet')
+      .withArgs(wilderDomainNameHash, addr1.address);
+  });
 
-    it("Should not allow owner to setAddress(0)", async function () {
-        await expect(znsAddressResolver.connect(owner).setAddress(wilderDomainNameHash, hre.ethers.constants.AddressZero)).to.be.revertedWith("ZNS: Cant set address to 0");
-    });
+  it('Should allow operator to setAddress and emit event', async () => {
+    await znsRegistry.connect(owner).setOwnerOperator(operator.address, true);
 
-    it("Should resolve address correctly", async function () {
-        await znsAddressResolver.connect(owner).setAddress(wilderDomainNameHash, addr1.address);
+    await expect(
+      znsAddressResolver.connect(operator)
+        .setAddress(wilderDomainNameHash, addr1.address)
+    )
+      .to.emit(znsAddressResolver, 'AddressSet')
+      .withArgs(wilderDomainNameHash, addr1.address);
+  });
 
-        const resolvedAddress = await znsAddressResolver.getAddress(wilderDomainNameHash);
-        expect(resolvedAddress).to.equal(addr1.address);
-    });
+  it('Should not allow owner to setAddress(0)', async () => {
+    await expect(
+      znsAddressResolver.connect(owner).setAddress(wilderDomainNameHash, hre.ethers.constants.AddressZero)
+    ).to.be.revertedWith('ZNS: Cant set address to 0');
+  });
 
-    it("Should support the IZNSAddressResolver interface ID", async function () {
-        const interfaceId = await znsAddressResolver.getInterfaceId();
-        const supported = await znsAddressResolver.supportsInterface(interfaceId);
-        expect(supported).to.be.true;
-    });
+  it('Should resolve address correctly', async () => {
+    await znsAddressResolver.connect(owner).setAddress(wilderDomainNameHash, addr1.address);
 
-    it("Should not support other interface IDs", async function () {
-        const notSupported = await znsAddressResolver.supportsInterface("0xffffffff");
-        expect(notSupported).to.be.false;
-    });
+    const resolvedAddress = await znsAddressResolver.getAddress(wilderDomainNameHash);
+    expect(resolvedAddress).to.equal(addr1.address);
+  });
+
+  it('Should support the IZNSAddressResolver interface ID', async () => {
+    const interfaceId = await znsAddressResolver.getInterfaceId();
+    const supported = await znsAddressResolver.supportsInterface(interfaceId);
+    expect(supported).to.be.true;
+  });
+
+  it('Should support the ERC-165 interface ID', async () => {
+    const erc165Interface = ERC165__factory.createInterface();
+    const interfaceId = erc165Interface.getSighash(erc165Interface.functions['supportsInterface(bytes4)']);
+    const supported = await znsAddressResolver.supportsInterface(interfaceId);
+    expect(supported).to.be.true;
+  });
+
+  it('Should not support other interface IDs', async () => {
+    const notSupported = await znsAddressResolver.supportsInterface('0xffffffff');
+    expect(notSupported).to.be.false;
+  });
 });

--- a/test/ZNSAddressResolver.test.ts
+++ b/test/ZNSAddressResolver.test.ts
@@ -45,10 +45,12 @@ describe("ZNSAddressResolver", function () {
         const someDomainHash = hre.ethers.utils.id("random-record");
         const notExistResolver = await znsRegistry.getDomainResolver(someDomainHash);
         expect(notExistResolver).to.eq(hre.ethers.constants.AddressZero);
-    })
+    });
+
     it("Should have registry address correctly set", async function () {
         expect(await znsAddressResolver.registry()).to.equal(znsRegistry.address);
     });
+
     it("Should not allow non-owner address to setAddress", async function () {
         await expect(znsAddressResolver.connect(addr1).setAddress(wilderDomainNameHash, addr1.address)).to.be.revertedWith("ZNS: Not allowed");
     });
@@ -63,9 +65,10 @@ describe("ZNSAddressResolver", function () {
         const resolvedAddress = await znsAddressResolver.getAddress(wilderDomainNameHash);
         expect(resolvedAddress).to.equal(addr1.address);
     });
-    it("Should support its own calculated interface ID", async function () {
-        const selector = znsAddressResolver.calculateSelector();
-        const supported = await znsAddressResolver.supportsInterface(selector);
+
+    it("Should support the IZNSAddressResolver interface ID", async function () {
+        const interfaceId = await znsAddressResolver.getInterfaceId();
+        const supported = await znsAddressResolver.supportsInterface(interfaceId);
         expect(supported).to.be.true;
     });
 

--- a/test/ZNSAddressResolver.test.ts
+++ b/test/ZNSAddressResolver.test.ts
@@ -1,0 +1,70 @@
+const { expect } = require("chai");
+import * as hre from "hardhat";
+import { ZNSAddressResolver, ZNSAddressResolver__factory } from "../typechain";
+import { ZNSRegistry, ZNSRegistry__factory } from "../typechain";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+
+/**
+ * TODO the registry should have a function for checking isOwnerOrOperator, 
+ * rather than the modifier also being added to AddressResolver
+ */
+describe("ZNSAddressResolver", function () {
+    let deployer: SignerWithAddress;
+    let znsAddressResolver: ZNSAddressResolver;
+    let znsRegistry: ZNSRegistry;
+    let owner: SignerWithAddress;
+    let addr1: SignerWithAddress;
+    let operator: SignerWithAddress;
+    let mockResolver: SignerWithAddress;
+    const rootDomainHash = hre.ethers.constants.HashZero;
+    const wilderLabel = hre.ethers.utils.id("wilder");
+    const zeroLabel = hre.ethers.utils.id("zero");
+    const wilderSubdomainHash = hre.ethers.utils.solidityKeccak256(["bytes32", "bytes32"], [rootDomainHash, wilderLabel]);
+
+
+    beforeEach(async function () {
+        [owner, addr1] = await hre.ethers.getSigners();
+        [deployer, operator, mockResolver] = await hre.ethers.getSigners();
+
+        const znsAddressResolverFactory = new ZNSAddressResolver__factory(deployer);
+        const znsRegistryFactory = new ZNSRegistry__factory(deployer);
+
+        znsRegistry = await znsRegistryFactory.deploy();
+        znsAddressResolver = await znsAddressResolverFactory.deploy(znsRegistry.address);
+
+        await znsRegistry.connect(deployer).initialize(deployer.address);
+        await znsRegistry.connect(deployer).setSubdomainRecord(rootDomainHash, wilderLabel, deployer.address, mockResolver.address);
+    });
+
+    it("Should have registry address correctly set", async function () {
+        expect(await znsAddressResolver.registry()).to.equal(znsRegistry.address);
+    });
+
+    it("Should not allow non-owner address to setAddress", async function () {
+        const domainNameHash = hre.ethers.utils.solidityKeccak256(["bytes32", "bytes32"], [rootDomainHash, wilderLabel]);
+        await expect(znsAddressResolver.connect(addr1).setAddress(domainNameHash, addr1.address)).to.be.revertedWith("ZNS: Not allowed");
+    });
+
+    it("Should allow owner to setAddress and emit event", async function () {
+        const domainNameHash = hre.ethers.utils.solidityKeccak256(["bytes32", "bytes32"], [rootDomainHash, wilderLabel]);
+        await expect(znsAddressResolver.connect(owner).setAddress(domainNameHash, addr1.address)).to.emit(znsAddressResolver, "AddressSet").withArgs(domainNameHash, addr1.address);
+    });
+
+    it("Should resolve address correctly", async function () {
+        const domainNameHash = hre.ethers.utils.solidityKeccak256(["bytes32", "bytes32"], [rootDomainHash, wilderLabel]);
+        await znsAddressResolver.connect(owner).setAddress(domainNameHash, addr1.address);
+
+        const resolvedAddress = await znsAddressResolver.getAddress(domainNameHash);
+        expect(resolvedAddress).to.equal(addr1.address);
+    });
+
+    it("Should support its own calculated interface ID", async function () {
+        const supported = await znsAddressResolver.supportsInterface(znsAddressResolver.calculateSelector());
+        expect(supported).to.be.true;
+    });
+
+    it("Should not support other interface IDs", async function () {
+        const notSupported = await znsAddressResolver.supportsInterface("0xffffffff");
+        expect(notSupported).to.be.false;
+    });
+});

--- a/test/ZNSAddressResolver.test.ts
+++ b/test/ZNSAddressResolver.test.ts
@@ -6,7 +6,9 @@ import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 
 /**
  * TODO the registry should have a function for checking isOwnerOrOperator, 
- * rather than the modifier also being added to AddressResolver
+ * so that the AddressResolver can implement a single call in its modifier.
+ * 
+ * Consider moving these tests to ZNSRegistry since they deploy a registry.
  */
 describe("ZNSAddressResolver", function () {
     let deployer: SignerWithAddress;
@@ -15,16 +17,13 @@ describe("ZNSAddressResolver", function () {
     let owner: SignerWithAddress;
     let addr1: SignerWithAddress;
     let operator: SignerWithAddress;
-    let mockResolver: SignerWithAddress;
     const rootDomainHash = hre.ethers.constants.HashZero;
     const wilderLabel = hre.ethers.utils.id("wilder");
-    const zeroLabel = hre.ethers.utils.id("zero");
-    const wilderSubdomainHash = hre.ethers.utils.solidityKeccak256(["bytes32", "bytes32"], [rootDomainHash, wilderLabel]);
-
+    const wilderDomainNameHash = hre.ethers.utils.solidityKeccak256(["bytes32", "bytes32"], [rootDomainHash, wilderLabel]);
 
     beforeEach(async function () {
         [owner, addr1] = await hre.ethers.getSigners();
-        [deployer, operator, mockResolver] = await hre.ethers.getSigners();
+        [deployer, operator] = await hre.ethers.getSigners();
 
         const znsAddressResolverFactory = new ZNSAddressResolver__factory(deployer);
         const znsRegistryFactory = new ZNSRegistry__factory(deployer);
@@ -32,34 +31,41 @@ describe("ZNSAddressResolver", function () {
         znsRegistry = await znsRegistryFactory.deploy();
         znsAddressResolver = await znsAddressResolverFactory.deploy(znsRegistry.address);
 
+        //Initialize registry and domain
         await znsRegistry.connect(deployer).initialize(deployer.address);
-        await znsRegistry.connect(deployer).setSubdomainRecord(rootDomainHash, wilderLabel, deployer.address, mockResolver.address);
+        await znsRegistry.connect(deployer).setSubdomainRecord(rootDomainHash, wilderLabel, deployer.address, znsAddressResolver.address);
     });
 
+    it("Should get the AddressResolver", async () => { // Copy of registry tests
+        // The domain exists
+        const existResolver = await znsRegistry.getDomainResolver(wilderDomainNameHash);
+        expect(existResolver).to.eq(znsAddressResolver.address);
+
+        // The domain does not exist
+        const someDomainHash = hre.ethers.utils.id("random-record");
+        const notExistResolver = await znsRegistry.getDomainResolver(someDomainHash);
+        expect(notExistResolver).to.eq(hre.ethers.constants.AddressZero);
+    })
     it("Should have registry address correctly set", async function () {
         expect(await znsAddressResolver.registry()).to.equal(znsRegistry.address);
     });
-
     it("Should not allow non-owner address to setAddress", async function () {
-        const domainNameHash = hre.ethers.utils.solidityKeccak256(["bytes32", "bytes32"], [rootDomainHash, wilderLabel]);
-        await expect(znsAddressResolver.connect(addr1).setAddress(domainNameHash, addr1.address)).to.be.revertedWith("ZNS: Not allowed");
+        await expect(znsAddressResolver.connect(addr1).setAddress(wilderDomainNameHash, addr1.address)).to.be.revertedWith("ZNS: Not allowed");
     });
 
     it("Should allow owner to setAddress and emit event", async function () {
-        const domainNameHash = hre.ethers.utils.solidityKeccak256(["bytes32", "bytes32"], [rootDomainHash, wilderLabel]);
-        await expect(znsAddressResolver.connect(owner).setAddress(domainNameHash, addr1.address)).to.emit(znsAddressResolver, "AddressSet").withArgs(domainNameHash, addr1.address);
+        await expect(znsAddressResolver.connect(owner).setAddress(wilderDomainNameHash, addr1.address)).to.emit(znsAddressResolver, "AddressSet").withArgs(wilderDomainNameHash, addr1.address);
     });
 
     it("Should resolve address correctly", async function () {
-        const domainNameHash = hre.ethers.utils.solidityKeccak256(["bytes32", "bytes32"], [rootDomainHash, wilderLabel]);
-        await znsAddressResolver.connect(owner).setAddress(domainNameHash, addr1.address);
+        await znsAddressResolver.connect(owner).setAddress(wilderDomainNameHash, addr1.address);
 
-        const resolvedAddress = await znsAddressResolver.getAddress(domainNameHash);
+        const resolvedAddress = await znsAddressResolver.getAddress(wilderDomainNameHash);
         expect(resolvedAddress).to.equal(addr1.address);
     });
-
     it("Should support its own calculated interface ID", async function () {
-        const supported = await znsAddressResolver.supportsInterface(znsAddressResolver.calculateSelector());
+        const selector = znsAddressResolver.calculateSelector();
+        const supported = await znsAddressResolver.supportsInterface(selector);
         expect(supported).to.be.true;
     });
 

--- a/test/ZNSAddressResolver.test.ts
+++ b/test/ZNSAddressResolver.test.ts
@@ -59,6 +59,10 @@ describe("ZNSAddressResolver", function () {
         await expect(znsAddressResolver.connect(owner).setAddress(wilderDomainNameHash, addr1.address)).to.emit(znsAddressResolver, "AddressSet").withArgs(wilderDomainNameHash, addr1.address);
     });
 
+    it("Should not allow owner to setAddress(0)", async function () {
+        await expect(znsAddressResolver.connect(owner).setAddress(wilderDomainNameHash, hre.ethers.constants.AddressZero)).to.be.revertedWith("ZNS: Cant set address to 0");
+    });
+
     it("Should resolve address correctly", async function () {
         await znsAddressResolver.connect(owner).setAddress(wilderDomainNameHash, addr1.address);
 

--- a/test/ZNSRegistry.test.ts
+++ b/test/ZNSRegistry.test.ts
@@ -16,6 +16,7 @@ require('@nomicfoundation/hardhat-chai-matchers');
 describe('ZNSRegistry Tests', () => {
   let deployer : SignerWithAddress;
   let operator : SignerWithAddress;
+  let randomUser : SignerWithAddress;
 
   // ZNSResolver has not been created, but an address will be equivalent for now
   let mockResolver : SignerWithAddress;
@@ -26,10 +27,12 @@ describe('ZNSRegistry Tests', () => {
   const wilderLabel = hre.ethers.utils.id('wilder');
 
   // Wilder subdomain hash created in `setSubdomainRecord` call to `setSubdomainOwner`
+  // TODO:  change all the calls for hashing in all the tests to use ENS `namehash` lib
+  //        that checks and validates strings before hashing
   const wilderSubdomainHash = hre.ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], [rootDomainHash, wilderLabel]);
 
   beforeEach(async () => {
-    [deployer, operator, mockResolver] = await hre.ethers.getSigners();
+    [deployer, operator, mockResolver, randomUser] = await hre.ethers.getSigners();
 
     const registryFactory = new ZNSRegistry__factory(deployer);
     registry = await registryFactory.deploy();
@@ -90,6 +93,19 @@ describe('ZNSRegistry Tests', () => {
   });
 
   describe('Domain and subdomain records', async () => {
+    it('Checks existence of a domain correctly', async () => {
+      const exists = await registry.connect(randomUser).exists(wilderSubdomainHash);
+      expect(exists).to.be.true;
+
+      const nonExistentDomainHash = hre.ethers.utils
+        .solidityKeccak256(
+          ['bytes32'],
+          [hre.ethers.utils.id('wild')]
+        );
+      const notExists = await registry.connect(randomUser).exists(nonExistentDomainHash);
+      expect(notExists).to.be.false;
+    });
+
     it('Gets a domain record', async () => {
       // Domain exists
       const rootRecord = await registry.getDomainRecord(rootDomainHash);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1517,14 +1517,7 @@
   resolved "https://registry.yarnpkg.com/@sigstore/protobuf-specs/-/protobuf-specs-0.1.0.tgz#957cb64ea2f5ce527cc9cf02a096baeb0d2b99b4"
   integrity sha512-a31EnjuIDSX8IXBUib3cYLDRlPMU36AWX4xS8ysLaNu4ZzUesDiPt83pgrW2X1YLMe5L2HbDyaKK5BrL4cNKaQ==
 
-"@solidity-parser/parser@^0.14.0", "@solidity-parser/parser@^0.14.1":
-  version "0.14.5"
-  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.14.5.tgz#87bc3cc7b068e08195c219c91cd8ddff5ef1a804"
-  integrity sha512-6dKnHZn7fg/iQATVEzqyUOyEidbn05q7YA2mQ9hC0MMXhhV3/JrsxmFSYZAcr7j1yUP700LLhTruvJ3MiQmjJg==
-  dependencies:
-    antlr4ts "^0.5.0-alpha.4"
-
-"@solidity-parser/parser@^0.16.0":
+"@solidity-parser/parser@0.16.0", "@solidity-parser/parser@^0.14.0", "@solidity-parser/parser@^0.14.1", "@solidity-parser/parser@^0.16.0":
   version "0.16.0"
   resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.16.0.tgz#1fb418c816ca1fc3a1e94b08bcfe623ec4e1add4"
   integrity sha512-ESipEcHyRHg4Np4SqBCfcXwyxxna1DgFVz69bgpLV8vzl/NP1DtcKsJ4dJZXWQhY/Z4J2LeKBiOkOVZn9ct33Q==


### PR DESCRIPTION
Setter permission is now the onlyOwnerOrOperator() condition on the registry.
To get that same condition on the resolver, I had to call both getDomainRecord() and isAllowedOperator.
We could reduce that to one call if the registry had a function that is just modified with onlyOwnerOrOperator()

AddressResolver tests include setting up a registry, so they could be moved into the registry tests, replacing the mockResolver made there.