### PR TITLE
feat: ZNSPriceOracle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
           pkg-manager: yarn
       - run: yarn build
       - run: yarn test # Validate Unit Tests Pass
+      - run: yarn lint
       - persist_to_workspace:
           root: ~/repo
           paths: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,8 @@ jobs:
       - node/install-packages:
           pkg-manager: yarn
       - run: yarn build
-      - run: yarn test # Validate Unit Tests Pass
       - run: yarn lint
+      - run: yarn test # Validate Unit Tests Pass
       - persist_to_workspace:
           root: ~/repo
           paths: .

--- a/.eslintrc
+++ b/.eslintrc
@@ -3,12 +3,11 @@
   "overrides": [
     {
       "files": ["src/**/*.ts", "test/**/*.ts", "./*.ts"],
-      "extends": ["@zero-tech/eslint-config-cpt/node-ts/.eslintrc.json"]
-    },
-    {
-      "files": ["*.test.ts"],
+      "extends": ["@zero-tech/eslint-config-cpt/node-ts/.eslintrc.json"],
       "rules": {
-        "no-unused-expressions": "off"
+        "no-unused-expressions": "off",
+        "@typescript-eslint/quotes": "off",
+        "@typescript-eslint/type-annotation-spacing": "off"
       }
     }
   ]

--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,6 @@
       "extends": ["@zero-tech/eslint-config-cpt/node-ts/.eslintrc.json"],
       "rules": {
         "no-unused-expressions": "off",
-        "@typescript-eslint/type-annotation-spacing": "off"
       }
     }
   ]

--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,6 @@
       "extends": ["@zero-tech/eslint-config-cpt/node-ts/.eslintrc.json"],
       "rules": {
         "no-unused-expressions": "off",
-        "@typescript-eslint/quotes": "off",
         "@typescript-eslint/type-annotation-spacing": "off"
       }
     }

--- a/contracts/IZNSPriceOracle.sol
+++ b/contracts/IZNSPriceOracle.sol
@@ -2,9 +2,11 @@
 pragma solidity ^0.8.18;
 
 interface IZNSPriceOracle {
-  event BasePriceSet(uint price, bool isSubdomain);
-  event PriceMultiplierSet(uint multiplier);
-  event BaseLengthSet(uint8 length);
+  event BasePriceSet(uint256 price, bool isSubdomain);
+  event PriceMultiplierSet(uint256 multiplier);
+  event BaseLengthSet(uint8 length, bool isRootDomain);
+  event BaseLengthsSet(uint8 rootDomainLength, uint8 subdomainLength);
+  event ZNSRegistrarSet(address registrar);
 
   /**
    * @notice Get the price of a given domain name length
@@ -12,9 +14,9 @@ interface IZNSPriceOracle {
    * @param isRootDomain Flag for which base price to use. True for subdomain, false for root.
    */
   function getPrice(
-    uint8 length,
+    string calldata length,
     bool isRootDomain
-  ) external view returns (uint);
+  ) external view returns (uint256);
 
   /**
    * @notice Set the base price for root domains
@@ -23,10 +25,7 @@ interface IZNSPriceOracle {
    * @param basePrice The price to set in $ZERO
    * @param isRootDomain Flag for if the price is to be set for a root or subdomain
    */
-  function setBasePrice(
-    uint basePrice,
-    bool isRootDomain
-  ) external;
+  function setBasePrice(uint256 basePrice, bool isRootDomain) external;
 
   /**
    * @notice In price calculation we use a `multiplier` to adjust how steep the
@@ -35,14 +34,22 @@ interface IZNSPriceOracle {
    *
    * @param multiplier The new price multiplier to set
    */
-  function setPriceMultiplier(uint16 multiplier) external;
+  function setPriceMultiplier(uint256 multiplier) external;
 
   /**
    * @notice Set the value of the domain name length boundary where the default price applies
    * e.g. A value of '5' means all domains <= 5 in length cost the default price
    * @param length Boundary to set
+   * @param isRootDomain Flag for if the price is to be set for a root or subdomain
    */
-  function setBaseLength(uint8 length) external;
+  function setBaseLength(uint8 length, bool isRootDomain) external;
+
+  /**
+   * @notice Set the value of both base lengt variables
+   * @param rootLength The length for root domains
+   * @param subdomainLength The length for subdomains
+   */
+  function setBaseLengths(uint8 rootLength, uint8 subdomainLength) external;
 
   /**
    * @notice Set the ZNSRegistrar for this contract

--- a/contracts/IZNSPriceOracle.sol
+++ b/contracts/IZNSPriceOracle.sol
@@ -35,7 +35,7 @@ interface IZNSPriceOracle {
    *
    * @param multiplier The new price multiplier to set
    */
-  function setPriceMultipler(uint multiplier) external;
+  function setPriceMultiplier(uint16 multiplier) external;
 
   /**
    * @notice Set the value of the domain name length boundary where the default price applies

--- a/contracts/IZNSPriceOracle.sol
+++ b/contracts/IZNSPriceOracle.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+interface IZNSPriceOracle {
+  event BasePriceSet(uint price, bool isSubdomain);
+  event PriceMultiplierSet(uint multiplier);
+}

--- a/contracts/IZNSPriceOracle.sol
+++ b/contracts/IZNSPriceOracle.sol
@@ -4,4 +4,5 @@ pragma solidity ^0.8.18;
 interface IZNSPriceOracle {
   event BasePriceSet(uint price, bool isSubdomain);
   event PriceMultiplierSet(uint multiplier);
+  event BaseLengthSet(uint8 length);
 }

--- a/contracts/IZNSPriceOracle.sol
+++ b/contracts/IZNSPriceOracle.sol
@@ -5,4 +5,54 @@ interface IZNSPriceOracle {
   event BasePriceSet(uint price, bool isSubdomain);
   event PriceMultiplierSet(uint multiplier);
   event BaseLengthSet(uint8 length);
+
+  /**
+   * @notice Get the price of a given domain name length
+   * @param length The length of the name to check
+   * @param isRootDomain Flag for which base price to use. True for subdomain, false for root.
+   */
+  function getPrice(
+    uint8 length,
+    bool isRootDomain
+  ) external view returns (uint);
+
+  /**
+   * @notice Set the base price for root domains
+   * If this value or the `priceMultiplier` value is `0` the price of any domain will also be `0`
+   *
+   * @param basePrice The price to set in $ZERO
+   * @param isRootDomain Flag for if the price is to be set for a root or subdomain
+   */
+  function setBasePrice(
+    uint basePrice,
+    bool isRootDomain
+  ) external;
+
+  /**
+   * @notice In price calculation we use a `multiplier` to adjust how steep the
+   * price curve is after the base price. This allows that value to be changed.
+   * If this value or the `basePrice` is `0` the price of any domain will also be `0`
+   *
+   * @param multiplier The new price multiplier to set
+   */
+  function setPriceMultipler(uint multiplier) external;
+
+  /**
+   * @notice Set the value of the domain name length boundary where the default price applies
+   * e.g. A value of '5' means all domains <= 5 in length cost the default price
+   * @param length Boundary to set
+   */
+  function setBaseLength(uint8 length) external;
+
+  /**
+   * @notice Set the ZNSRegistrar for this contract
+   * @param registrar The registrar to set
+   */
+  function setZNSRegistrar(address registrar) external;
+
+  /**
+   * @notice Return true if a user is authorized, otherwise false
+   * @param user The user to check
+   */
+  function isAuthorized(address user) external view returns (bool);
 }

--- a/contracts/ZNSAddressResolver.sol
+++ b/contracts/ZNSAddressResolver.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.18;
 
-import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
-import "./IZNSAddressResolver.sol";
-import "./IZNSRegistry.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {IZNSAddressResolver} from "./IZNSAddressResolver.sol";
+import {IZNSRegistry} from "./IZNSRegistry.sol";
 
 contract ZNSAddressResolver is ERC165, IZNSAddressResolver {
   /**

--- a/contracts/ZNSPriceOracle.sol
+++ b/contracts/ZNSPriceOracle.sol
@@ -174,6 +174,10 @@ contract ZNSPriceOracle is IZNSPriceOracle, Initializable {
    */
   function _setZNSRegistrar(address registrar) internal {
     require(registrar != address(0), "ZNS: Zero address for Registrar");
+
+    // Modify the access control for the new registrar
+    authorized[znsRegistrar] =  false;
     znsRegistrar = registrar;
+    authorized[registrar] = true;
   }
 }

--- a/contracts/ZNSPriceOracle.sol
+++ b/contracts/ZNSPriceOracle.sol
@@ -9,28 +9,30 @@ contract ZNSPriceOracle is IZNSPriceOracle, Initializable {
   /**
    * @notice Base price for root domains
    */
-  uint public rootDomainBasePrice;
+  uint256 public rootDomainBasePrice;
 
   /**
    * @notice Base price for subdomains
    */
-  uint public subdomainBasePrice;
+  uint256 public subdomainBasePrice;
 
   /**
    * @notice The price multiplier used in calculation for a given domain name's length
    * We store this value with two decimals of precision for division later in calculation
    * This means if we use a multiplier of 3.9, it is stored as 390
-   * Note that 3.9 is recommended but is an arbitrary choice to use as a multiplier. We use 
+   * Note that 3.9 is recommended but is an arbitrary choice to use as a multiplier. We use
    * it here because it creates a reasonable decline in pricing visually when graphed.
    */
-  uint16 public priceMultiplier;
+  uint256 public priceMultiplier;
 
   /**
    * @notice The base domain name length is used in pricing to identify domains
    * that should recieve the default base price for that type of domain or not.
    * Domains that are `<= baseLength` will receive the default base price.
    */
-  uint8 public baseLength;
+  uint8 public rootDomainBaseLength;
+
+  uint8 public subdomainBaseLength;
 
   /**
    * @notice The address of the ZNS Registrar we are using
@@ -52,39 +54,46 @@ contract ZNSPriceOracle is IZNSPriceOracle, Initializable {
   }
 
   function initialize(
-    uint rootDomainBasePrice_,
-    uint subdomainBasePrice_,
-    uint16 priceMultiplier_,
-    uint8 baseLength_,
+    uint256 rootDomainBasePrice_,
+    uint256 subdomainBasePrice_,
+    uint256 priceMultiplier_,
+    uint8 rootDomainBaseLength_,
+    uint8 subdomainBaseLength_,
     address znsRegistrar_
   ) public initializer {
     rootDomainBasePrice = rootDomainBasePrice_;
     subdomainBasePrice = subdomainBasePrice_;
     priceMultiplier = priceMultiplier_;
-    baseLength = baseLength_;
+    rootDomainBaseLength = rootDomainBaseLength_;
+    subdomainBaseLength = subdomainBaseLength_;
 
     _setZNSRegistrar(znsRegistrar_);
-    
+
     authorized[msg.sender] = true;
     authorized[znsRegistrar_] = true;
   }
 
   /**
    * @notice Get the price of a given domain name length
-   * @param length The length of the name to check
+   * @param name The name of the domain to check
    * @param isRootDomain Flag for which base price to use. True for root, false for subdomains
    */
   function getPrice(
-    uint8 length,
+    string calldata name,
     bool isRootDomain
-  ) external view returns (uint) {
+  ) external view returns (uint256) {
+    // TODO Getting string length this way may be misleading
+    // when considering unicode encoded characters. Find a
+    // better solution for this
+    uint8 length = uint8(bytes(name).length);
+
     // No pricing is set for 0 length domains
     if (length == 0) return 0;
 
     if (isRootDomain) {
-      return _getPrice(length, rootDomainBasePrice);
+      return _getPrice(length, rootDomainBaseLength, rootDomainBasePrice);
     } else {
-      return _getPrice(length, subdomainBasePrice);
+      return _getPrice(length, subdomainBaseLength, subdomainBasePrice);
     }
   }
 
@@ -96,7 +105,7 @@ contract ZNSPriceOracle is IZNSPriceOracle, Initializable {
    * @param isRootDomain Flag for if the price is to be set for a root or subdomain
    */
   function setBasePrice(
-    uint basePrice,
+    uint256 basePrice,
     bool isRootDomain
   ) external onlyAuthorized {
     if (isRootDomain) {
@@ -113,10 +122,17 @@ contract ZNSPriceOracle is IZNSPriceOracle, Initializable {
    * price curve is after the base price. This allows that value to be changed.
    * If this value or the `basePrice` is `0` the price of any domain will also be `0`
    *
+   * Valid values for the multiplier range are between 300 - 400 inclusively.
+   * These are decimal values with two points of precision, meaning they are really 3.00 - 4.00
+   * but we can't store them this way. We divide by 100 in the below internal price function
+   * to make up for this.
    * @param multiplier The new price multiplier to set
    */
-  function setPriceMultiplier(uint16 multiplier) external onlyAuthorized {
-    require(multiplier >= 300 && multiplier <= 400, "ZNS: Multiplier out of range");
+  function setPriceMultiplier(uint256 multiplier) external onlyAuthorized {
+    require(
+      multiplier >= 300 && multiplier <= 400,
+      "ZNS: Multiplier out of range"
+    );
     priceMultiplier = multiplier;
 
     emit PriceMultiplierSet(multiplier);
@@ -126,11 +142,34 @@ contract ZNSPriceOracle is IZNSPriceOracle, Initializable {
    * @notice Set the value of the domain name length boundary where the default price applies
    * e.g. A value of '5' means all domains <= 5 in length cost the default price
    * @param length Boundary to set
+   * @param isRootDomain Flag for if the price is to be set for a root or subdomain
    */
-  function setBaseLength(uint8 length) external onlyAuthorized {
-    baseLength = length;
+  function setBaseLength(
+    uint8 length,
+    bool isRootDomain
+  ) external onlyAuthorized {
+    if (isRootDomain) {
+      rootDomainBaseLength = length;
+    } else {
+      subdomainBaseLength = length;
+    }
 
-    emit BaseLengthSet(length);
+    emit BaseLengthSet(length, isRootDomain);
+  }
+
+  /**
+   * @notice Set the value of both base lengt variables
+   * @param rootLength The length for root domains
+   * @param subdomainLength The length for subdomains
+   */
+  function setBaseLengths(
+    uint8 rootLength,
+    uint8 subdomainLength
+  ) external onlyAuthorized {
+    rootDomainBaseLength = rootLength;
+    subdomainBaseLength = subdomainLength;
+
+    emit BaseLengthsSet(rootLength, subdomainLength);
   }
 
   /**
@@ -139,6 +178,8 @@ contract ZNSPriceOracle is IZNSPriceOracle, Initializable {
    */
   function setZNSRegistrar(address registrar) external onlyAuthorized {
     _setZNSRegistrar(registrar);
+
+    emit ZNSRegistrarSet(registrar);
   }
 
   /**
@@ -158,18 +199,22 @@ contract ZNSPriceOracle is IZNSPriceOracle, Initializable {
    */
   function _getPrice(
     uint8 length,
-    uint basePrice
-  ) internal view returns (uint) {
+    uint8 baseLength,
+    uint256 basePrice
+  ) internal view returns (uint256) {
     if (length <= baseLength) return basePrice;
 
     // TODO truncate to everything after the decimal, we don't want fractional prices
     // Should this be here vs. in the dApp?
 
     // This creates an asymptotic curve that decreases in pricing based on domain name length
-    // Because there are no decimals in ETH we set the muliplier as 100x higher 
+    // Because there are no decimals in ETH we set the muliplier as 100x higher
     // than it is meant to be, so we divide by 100 to reverse that action here.
     // =(baseLength*basePrice*multiplier)/(length+(3*multiplier)
-    return (baseLength * priceMultiplier * basePrice) / (length + (3 * priceMultiplier)) / 100;
+    return
+      (baseLength * priceMultiplier * basePrice) /
+      (length + (3 * priceMultiplier)) /
+      100;
   }
 
   /**
@@ -180,7 +225,7 @@ contract ZNSPriceOracle is IZNSPriceOracle, Initializable {
     require(registrar != address(0), "ZNS: Zero address for Registrar");
 
     // Modify the access control for the new registrar
-    authorized[znsRegistrar] =  false;
+    authorized[znsRegistrar] = false;
     authorized[registrar] = true;
     znsRegistrar = registrar;
   }

--- a/contracts/ZNSPriceOracle.sol
+++ b/contracts/ZNSPriceOracle.sol
@@ -39,7 +39,7 @@ contract ZNSPriceOracle is IZNSPriceOracle, Initializable {
    * @notice Track authorized users or contracts
    * TODO access control
    */
-  mapping(address => bool) public authorized;
+  mapping(address user => bool isAuthorized) public authorized;
 
   /**
    * @notice Restrict a function to only be callable by authorized users

--- a/contracts/ZNSPriceOracle.sol
+++ b/contracts/ZNSPriceOracle.sol
@@ -39,7 +39,7 @@ contract ZNSPriceOracle is IZNSPriceOracle, Initializable {
   /**
    * @notice Track authorized users or contracts
    */
-  mapping(address => bool) authorized;
+  mapping(address => bool) public authorized;
 
   /**
    * @notice Restrict a function to only be callable by authorized users

--- a/contracts/ZNSPriceOracle.sol
+++ b/contracts/ZNSPriceOracle.sol
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {IZNSPriceOracle} from "./IZNSPriceOracle.sol";
+
+contract ZNSPriceOracle is IZNSPriceOracle, Initializable {
+  /**
+   * @notice Base price for root domains
+   */
+  uint public rootDomainBasePrice;
+
+  /**
+   * @notice Base price for subdomains
+   */
+  uint public subdomainBasePrice;
+
+  /**
+   * @notice The price multiplier used in calculation for a given domain name's length
+   * Note, 3.9 is an arbitrary choice to use as a multiplier. I used it because it created
+   * a reasonable decline in pricing form visually when graphed.
+   */
+  uint priceMultiplier = 39 * 10 ** 17;
+
+  /**
+   * @notice The address of the ZNS Registrar we are using
+   */
+  address public znsRegistrar;
+
+  /**
+   * @notice Track authorized users or contracts
+   */
+  mapping(address => bool) authorized;
+
+  /**
+   * @notice Restrict a function to only be callable by authorized users
+   */
+  modifier onlyAuthorized() {
+    require(authorized[msg.sender], "ZNS: Not authorized");
+    _;
+  }
+
+  function initialize(
+    uint rootDomainBasePrice_,
+    uint subdomainBasePrice_,
+    address znsRegistrar_
+  ) public initializer {
+    rootDomainBasePrice = rootDomainBasePrice_;
+    subdomainBasePrice = subdomainBasePrice_;
+
+    znsRegistrar = znsRegistrar_;
+
+    authorized[msg.sender] = true;
+    authorized[znsRegistrar_] = true;
+  }
+
+  /**
+   * @notice Get the price of a given domain name length
+   * @param length The length of the name to check
+   * @param isSubdomain Flag for which base price to use
+   */
+  function getPrice(
+    uint8 length,
+    bool isSubdomain
+  ) external view returns (uint) {
+    // No pricing is set for 0 length domains
+    if (length == 0) return 0;
+
+    if (isSubdomain) {
+      return _getPrice(length, subdomainBasePrice);
+    } else {
+      return _getPrice(length, rootDomainBasePrice);
+    }
+  }
+
+  /**
+   * @notice Set the base price for root domains
+   * If this value or the `priceMultiplier` value is `0` the price of any domain will also be `0`
+   *
+   * @param basePrice The price to set in $ZERO
+   * @param isSubdomain Flag for if the price is to be set for a root or subdomain
+   */
+  function setBasePrice(
+    uint basePrice,
+    bool isSubdomain
+  ) external onlyAuthorized {
+    if (isSubdomain) {
+      subdomainBasePrice = basePrice;
+    } else {
+      rootDomainBasePrice = basePrice;
+    }
+
+    emit BasePriceSet(basePrice, isSubdomain);
+  }
+
+  /**
+   * @notice In price calculation we use a `multiplier` to adjust how steep the
+   * price curve is after the base price. This allows that value to be changed.
+   * If this value or the `basePrice` is `0` the price of any domain will also be `0`
+   *
+   * @param multiplier The new price multiplier to set
+   */
+  function setPriceMultipler(uint multiplier) external onlyAuthorized {
+    priceMultiplier = multiplier;
+
+    emit PriceMultiplierSet(multiplier);
+  }
+
+  /**
+   * @notice Return true if a user is authorized, otherwise false
+   * @param user The user to check
+   */
+  function isAuthorized(address user) external view returns (bool) {
+    return authorized[user];
+  }
+
+  /**
+   * @notice Internal function to get price abstract of the base price being for
+   * a root domain or a subdomain.
+   *
+   * @param length The length of the domain name
+   * @param basePrice The base price to calculate with
+   */
+  function _getPrice(
+    uint8 length,
+    uint basePrice
+  ) internal view returns (uint) {
+    if (length <= 3) return basePrice;
+
+    // TODO truncate to everything after the decimal, we don't want fractional prices
+
+    // The price function is `price = (basePrice * 3.9) / length`
+    // This creates an asymptotic curve that decreases in pricing base on length
+    return (basePrice * priceMultiplier) / length;
+  }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -8,7 +8,7 @@ import '@nomicfoundation/hardhat-network-helpers';
 import '@nomicfoundation/hardhat-chai-matchers';
 import 'solidity-coverage';
 
-const config : HardhatUserConfig = {
+const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       {
@@ -32,7 +32,7 @@ const config : HardhatUserConfig = {
     outDir: 'typechain',
   },
   mocha: {
-    timeout: 40000,
+    timeout: 5000000,
   },
   networks: {
     mainnet: {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/chai": "4.2.0",
     "@types/mocha": "9.1.0",
     "@types/node": "^18.15.11",
-    "@zero-tech/eslint-config-cpt": "0.2.4",
+    "@zero-tech/eslint-config-cpt": "0.2.5",
     "chai": "4.2.0",
     "eslint": "^8.37.0",
     "ethers": "5.4.7",

--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
     "solidity-coverage": "^0.8.2",
     "ts-node": "10.9.1",
     "typechain": "8.1.0",
-    "typescript": "^5.0.2",
-    "typescript-eslint": "^0.0.1-alpha.0"
+    "typescript": "^5.0.2"
   },
   "dependencies": {
     "dotenv": "16.0.3"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "lint"
   ],
   "devDependencies": {
-    "@zero-tech/eslint-config-cpt": "0.2.4",
     "@ethersproject/providers": "5.7.2",
     "@nomicfoundation/hardhat-chai-matchers": "1.0.6",
     "@nomicfoundation/hardhat-network-helpers": "^1.0.8",
@@ -38,9 +37,10 @@
     "@semantic-release/git": "^10.0.1",
     "@typechain/ethers-v5": "10.1.0",
     "@typechain/hardhat": "6.1.2",
-    "@types/node": "^18.15.11",
     "@types/chai": "4.2.0",
     "@types/mocha": "9.1.0",
+    "@types/node": "^18.15.11",
+    "@zero-tech/eslint-config-cpt": "0.2.4",
     "chai": "4.2.0",
     "eslint": "^8.37.0",
     "ethers": "5.4.7",
@@ -48,11 +48,12 @@
     "hardhat-gas-reporter": "1.0.8",
     "logdown": "3.3.1",
     "semantic-release": "^21.0.1",
+    "solhint": "^3.4.1",
     "solidity-coverage": "^0.8.2",
     "ts-node": "10.9.1",
     "typechain": "8.1.0",
     "typescript": "^5.0.2",
-    "solhint": "^3.4.1"
+    "typescript-eslint": "^0.0.1-alpha.0"
   },
   "dependencies": {
     "dotenv": "16.0.3"

--- a/test/ZNSAddressResolver.test.ts
+++ b/test/ZNSAddressResolver.test.ts
@@ -1,22 +1,22 @@
-import * as hre from 'hardhat';
+import * as hre from "hardhat";
 import {
   ZNSRegistry,
   ZNSRegistry__factory,
   ZNSAddressResolver,
   ZNSAddressResolver__factory,
   ERC165__factory,
-} from '../typechain';
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+} from "../typechain";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const { expect } = require('chai');
+const { expect } = require("chai");
 /**
  * TODO the registry should have a function for checking isOwnerOrOperator,
  * so that the AddressResolver can implement a single call in its modifier.
  *
  * Consider moving these tests to ZNSRegistry since they deploy a registry.
  */
-describe('ZNSAddressResolver', () => {
+describe("ZNSAddressResolver", () => {
   let deployer: SignerWithAddress;
   let znsAddressResolver: ZNSAddressResolver;
   let znsRegistry: ZNSRegistry;
@@ -24,10 +24,10 @@ describe('ZNSAddressResolver', () => {
   let addr1: SignerWithAddress;
   let operator: SignerWithAddress;
   const rootDomainHash = hre.ethers.constants.HashZero;
-  const wilderLabel = hre.ethers.utils.id('wilder');
+  const wilderLabel = hre.ethers.utils.id("wilder");
   const wilderDomainNameHash = hre.ethers.utils
     .solidityKeccak256(
-      ['bytes32', 'bytes32'],
+      ["bytes32", "bytes32"],
       [rootDomainHash, wilderLabel]
     );
 
@@ -52,75 +52,75 @@ describe('ZNSAddressResolver', () => {
       );
   });
 
-  it('Should get the AddressResolver', async () => { // Copy of registry tests
+  it("Should get the AddressResolver", async () => { // Copy of registry tests
     // The domain exists
     const existResolver = await znsRegistry.getDomainResolver(wilderDomainNameHash);
     expect(existResolver).to.eq(znsAddressResolver.address);
 
     // The domain does not exist
-    const someDomainHash = hre.ethers.utils.id('random-record');
+    const someDomainHash = hre.ethers.utils.id("random-record");
     const notExistResolver = await znsRegistry.getDomainResolver(someDomainHash);
     expect(notExistResolver).to.eq(hre.ethers.constants.AddressZero);
   });
 
-  it('Should have registry address correctly set', async () => {
+  it("Should have registry address correctly set", async () => {
     expect(await znsAddressResolver.registry()).to.equal(znsRegistry.address);
   });
 
-  it('Should not allow non-owner address to setAddress', async () => {
+  it("Should not allow non-owner address to setAddress", async () => {
     await expect(
       znsAddressResolver.connect(addr1).setAddress(wilderDomainNameHash, addr1.address)
-    ).to.be.revertedWith('ZNS: Not allowed');
+    ).to.be.revertedWith("ZNS: Not allowed");
   });
 
-  it('Should allow owner to setAddress and emit event', async () => {
+  it("Should allow owner to setAddress and emit event", async () => {
     await expect(
       znsAddressResolver.connect(owner)
         .setAddress(wilderDomainNameHash, addr1.address)
     )
-      .to.emit(znsAddressResolver, 'AddressSet')
+      .to.emit(znsAddressResolver, "AddressSet")
       .withArgs(wilderDomainNameHash, addr1.address);
   });
 
-  it('Should allow operator to setAddress and emit event', async () => {
+  it("Should allow operator to setAddress and emit event", async () => {
     await znsRegistry.connect(owner).setOwnerOperator(operator.address, true);
 
     await expect(
       znsAddressResolver.connect(operator)
         .setAddress(wilderDomainNameHash, addr1.address)
     )
-      .to.emit(znsAddressResolver, 'AddressSet')
+      .to.emit(znsAddressResolver, "AddressSet")
       .withArgs(wilderDomainNameHash, addr1.address);
   });
 
-  it('Should not allow owner to setAddress(0)', async () => {
+  it("Should not allow owner to setAddress(0)", async () => {
     await expect(
       znsAddressResolver.connect(owner).setAddress(wilderDomainNameHash, hre.ethers.constants.AddressZero)
-    ).to.be.revertedWith('ZNS: Cant set address to 0');
+    ).to.be.revertedWith("ZNS: Cant set address to 0");
   });
 
-  it('Should resolve address correctly', async () => {
+  it("Should resolve address correctly", async () => {
     await znsAddressResolver.connect(owner).setAddress(wilderDomainNameHash, addr1.address);
 
     const resolvedAddress = await znsAddressResolver.getAddress(wilderDomainNameHash);
     expect(resolvedAddress).to.equal(addr1.address);
   });
 
-  it('Should support the IZNSAddressResolver interface ID', async () => {
+  it("Should support the IZNSAddressResolver interface ID", async () => {
     const interfaceId = await znsAddressResolver.getInterfaceId();
     const supported = await znsAddressResolver.supportsInterface(interfaceId);
     expect(supported).to.be.true;
   });
 
-  it('Should support the ERC-165 interface ID', async () => {
+  it("Should support the ERC-165 interface ID", async () => {
     const erc165Interface = ERC165__factory.createInterface();
-    const interfaceId = erc165Interface.getSighash(erc165Interface.functions['supportsInterface(bytes4)']);
+    const interfaceId = erc165Interface.getSighash(erc165Interface.functions["supportsInterface(bytes4)"]);
     const supported = await znsAddressResolver.supportsInterface(interfaceId);
     expect(supported).to.be.true;
   });
 
-  it('Should not support other interface IDs', async () => {
-    const notSupported = await znsAddressResolver.supportsInterface('0xffffffff');
+  it("Should not support other interface IDs", async () => {
+    const notSupported = await znsAddressResolver.supportsInterface("0xffffffff");
     expect(notSupported).to.be.false;
   });
 });

--- a/test/ZNSAddressResolver.test.ts
+++ b/test/ZNSAddressResolver.test.ts
@@ -4,7 +4,7 @@ import {
   ZNSRegistry__factory,
   ZNSAddressResolver,
   ZNSAddressResolver__factory,
-  IERC165__factory, ERC165__factory,
+  ERC165__factory,
 } from '../typechain';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
@@ -17,12 +17,12 @@ const { expect } = require('chai');
  * Consider moving these tests to ZNSRegistry since they deploy a registry.
  */
 describe('ZNSAddressResolver', () => {
-  let deployer : SignerWithAddress;
-  let znsAddressResolver : ZNSAddressResolver;
-  let znsRegistry : ZNSRegistry;
-  let owner : SignerWithAddress;
-  let addr1 : SignerWithAddress;
-  let operator : SignerWithAddress;
+  let deployer: SignerWithAddress;
+  let znsAddressResolver: ZNSAddressResolver;
+  let znsRegistry: ZNSRegistry;
+  let owner: SignerWithAddress;
+  let addr1: SignerWithAddress;
+  let operator: SignerWithAddress;
   const rootDomainHash = hre.ethers.constants.HashZero;
   const wilderLabel = hre.ethers.utils.id('wilder');
   const wilderDomainNameHash = hre.ethers.utils

--- a/test/ZNSAddressResolver.test.ts
+++ b/test/ZNSAddressResolver.test.ts
@@ -17,12 +17,12 @@ const { expect } = require("chai");
  * Consider moving these tests to ZNSRegistry since they deploy a registry.
  */
 describe("ZNSAddressResolver", () => {
-  let deployer: SignerWithAddress;
-  let znsAddressResolver: ZNSAddressResolver;
-  let znsRegistry: ZNSRegistry;
-  let owner: SignerWithAddress;
-  let addr1: SignerWithAddress;
-  let operator: SignerWithAddress;
+  let deployer : SignerWithAddress;
+  let znsAddressResolver : ZNSAddressResolver;
+  let znsRegistry : ZNSRegistry;
+  let owner : SignerWithAddress;
+  let addr1 : SignerWithAddress;
+  let operator : SignerWithAddress;
   const rootDomainHash = hre.ethers.constants.HashZero;
   const wilderLabel = hre.ethers.utils.id("wilder");
   const wilderDomainNameHash = hre.ethers.utils

--- a/test/ZNSDomainToken.test.ts
+++ b/test/ZNSDomainToken.test.ts
@@ -11,9 +11,9 @@ describe('ZNSDomainToken:', () => {
   const TokenName = 'ZNSDomainToken';
   const TokenSymbol = 'ZDT';
 
-  let deployer : SignerWithAddress;
-  let caller : SignerWithAddress;
-  let domainToken : ZNSDomainToken;
+  let deployer: SignerWithAddress;
+  let caller: SignerWithAddress;
+  let domainToken: ZNSDomainToken;
 
   beforeEach(async () => {
     [deployer, caller] = await hre.ethers.getSigners();

--- a/test/ZNSDomainToken.test.ts
+++ b/test/ZNSDomainToken.test.ts
@@ -1,15 +1,15 @@
-import * as hre from 'hardhat';
+import * as hre from "hardhat";
 import {
   ZNSDomainToken,
   ZNSDomainToken__factory,
-} from '../typechain';
-import { expect } from 'chai';
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
-import { ethers } from 'ethers';
+} from "../typechain";
+import { expect } from "chai";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { ethers } from "ethers";
 
-describe('ZNSDomainToken:', () => {
-  const TokenName = 'ZNSDomainToken';
-  const TokenSymbol = 'ZDT';
+describe("ZNSDomainToken:", () => {
+  const TokenName = "ZNSDomainToken";
+  const TokenSymbol = "ZDT";
 
   let deployer: SignerWithAddress;
   let caller: SignerWithAddress;
@@ -24,16 +24,16 @@ describe('ZNSDomainToken:', () => {
     domainToken = await domainTokenFactory.deploy();
   });
 
-  describe('External functions', () => {
-    it('Registers a token', async () => {
-      const tokenId = ethers.BigNumber.from('1');
+  describe("External functions", () => {
+    it("Registers a token", async () => {
+      const tokenId = ethers.BigNumber.from("1");
       const tx = await domainToken
         .connect(deployer)
         .register(caller.address, tokenId);
       const receipt = await tx.wait(0);
 
       // Verify Transfer event is emitted
-      expect(receipt.events?.[0].event).to.eq('Transfer');
+      expect(receipt.events?.[0].event).to.eq("Transfer");
       expect(receipt.events?.[0].args?.tokenId).to.eq(
         tokenId
       );
@@ -47,8 +47,8 @@ describe('ZNSDomainToken:', () => {
       );
     });
 
-    it('Revokes a token', async () => {
-      const tokenId = ethers.BigNumber.from('1');
+    it("Revokes a token", async () => {
+      const tokenId = ethers.BigNumber.from("1");
       // Mint domain
       await domainToken
         .connect(deployer)
@@ -65,7 +65,7 @@ describe('ZNSDomainToken:', () => {
       const receipt = await tx.wait(0);
 
       // Verify Transfer event is emitted
-      expect(receipt.events?.[0].event).to.eq('Transfer');
+      expect(receipt.events?.[0].event).to.eq("Transfer");
       expect(receipt.events?.[0].args?.tokenId).to.eq(
         tokenId
       );
@@ -76,13 +76,13 @@ describe('ZNSDomainToken:', () => {
       // Verify token has been burned
       expect(
         domainToken.ownerOf(tokenId)
-      ).to.be.revertedWith('ERC721: invalid token ID');
+      ).to.be.revertedWith("ERC721: invalid token ID");
     });
   });
 
-  describe('Require Statement Validation', () => {
-    it('Only owner can revoke a token', async () => {
-      const tokenId = ethers.BigNumber.from('1');
+  describe("Require Statement Validation", () => {
+    it("Only owner can revoke a token", async () => {
+      const tokenId = ethers.BigNumber.from("1");
       // Mint domain
       await domainToken
         .connect(deployer)
@@ -98,7 +98,7 @@ describe('ZNSDomainToken:', () => {
         .connect(deployer)
         .revoke(tokenId);
       await expect(tx).to.be.revertedWith(
-        'ZNSDomainToken: Owner of sender does not match Owner of token'
+        "ZNSDomainToken: Owner of sender does not match Owner of token"
       );
 
       // Verify token has not been burned
@@ -108,13 +108,13 @@ describe('ZNSDomainToken:', () => {
     });
   });
 
-  describe('Contract Configuration', () => {
-    it('Verify token name', async () => {
+  describe("Contract Configuration", () => {
+    it("Verify token name", async () => {
       const name = await domainToken.name();
       expect(name).to.equal(TokenName);
     });
 
-    it('Verify token symbol', async () => {
+    it("Verify token symbol", async () => {
       const symbol = await domainToken.symbol();
       expect(symbol).to.equal(TokenSymbol);
     });

--- a/test/ZNSDomainToken.test.ts
+++ b/test/ZNSDomainToken.test.ts
@@ -11,9 +11,9 @@ describe("ZNSDomainToken:", () => {
   const TokenName = "ZNSDomainToken";
   const TokenSymbol = "ZDT";
 
-  let deployer: SignerWithAddress;
-  let caller: SignerWithAddress;
-  let domainToken: ZNSDomainToken;
+  let deployer : SignerWithAddress;
+  let caller : SignerWithAddress;
+  let domainToken : ZNSDomainToken;
 
   beforeEach(async () => {
     [deployer, caller] = await hre.ethers.getSigners();

--- a/test/ZNSPriceOracle.test.ts
+++ b/test/ZNSPriceOracle.test.ts
@@ -13,8 +13,8 @@ describe("ZNSPriceOracle", () => {
   let contract: ZNSPriceOracle;
   let factory: ZNSPriceOracle__factory;
 
-  const rootDomainPrice = hre.ethers.utils.parseEther("1");
-  const subdomainPrice = hre.ethers.utils.parseEther("0.2");
+  const priceForRootDomain = hre.ethers.utils.parseEther("1");
+  const priceForSubdomain = hre.ethers.utils.parseEther("0.2");
 
   beforeEach(async () => {
     [deployer, user, mockRegistrar] = await hre.ethers.getSigners();
@@ -22,7 +22,7 @@ describe("ZNSPriceOracle", () => {
     factory = new ZNSPriceOracle__factory(deployer);
     contract = await factory.deploy();
 
-    await contract.initialize(rootDomainPrice, subdomainPrice, mockRegistrar.address);
+    await contract.initialize(priceForRootDomain, priceForSubdomain, mockRegistrar.address);
   });
 
   it("Confirms the mockRegistrar is authorized", async () => {
@@ -143,7 +143,7 @@ describe("ZNSPriceOracle", () => {
       const newBasePrice = hre.ethers.utils.parseEther("0.7");
 
       const tx = contract.connect(user).setBasePrice(newBasePrice, true);
-      expect(tx).to.be.revertedWith("ZNS: Not allowed")
+      expect(tx).to.be.revertedWith("ZNS: Not allowed");
     });
 
     it("Allows setting the price to zero", async () => {
@@ -170,7 +170,7 @@ describe("ZNSPriceOracle", () => {
       const newMultiplier = BigNumber.from("25");
 
       const tx = contract.connect(user).setPriceMultipler(newMultiplier);
-      expect(tx).to.be.revertedWith("ZNS: Not allowed")
+      expect(tx).to.be.revertedWith("ZNS: Not allowed");
     });
 
     it("Allows setting the multiplier to zero", async () => {
@@ -197,7 +197,7 @@ describe("ZNSPriceOracle", () => {
       const newBoundary = 5;
 
       const tx = contract.connect(user).setBaseLength(newBoundary);
-      expect(tx).to.be.revertedWith("ZNS: Not allowed")
+      expect(tx).to.be.revertedWith("ZNS: Not allowed");
     });
 
     it("Allows setting the boundary to zero", async () => {

--- a/test/ZNSPriceOracle.test.ts
+++ b/test/ZNSPriceOracle.test.ts
@@ -22,7 +22,16 @@ describe("ZNSPriceOracle", () => {
     factory = new ZNSPriceOracle__factory(deployer);
     contract = await factory.deploy();
 
-    await contract.initialize(priceForRootDomain, priceForSubdomain, mockRegistrar.address);
+    const priceMultiplier = BigNumber.from("39");
+    const baseLength = 3;
+
+    await contract.initialize(
+      priceForRootDomain,
+      priceForSubdomain,
+      priceMultiplier,
+      baseLength,
+      mockRegistrar.address
+    );
   });
 
   it("Confirms the mockRegistrar is authorized", async () => {
@@ -166,7 +175,7 @@ describe("ZNSPriceOracle", () => {
       expect(updatedMultiplier).to.eq(newMultiplier);
     });
 
-    it("Disallows an unauthorized user to set the base price", async () => {
+    it("Disallows an unauthorized user to set the price multiplier", async () => {
       const newMultiplier = BigNumber.from("25");
 
       const tx = contract.connect(user).setPriceMultipler(newMultiplier);
@@ -193,7 +202,7 @@ describe("ZNSPriceOracle", () => {
       expect(updatedBoundary).to.eq(newBoundary);
     });
 
-    it("Disallows an unauthorized user to set the base price", async () => {
+    it("Disallows an unauthorized user to set the base length", async () => {
       const newBoundary = 5;
 
       const tx = contract.connect(user).setBaseLength(newBoundary);

--- a/test/ZNSPriceOracle.test.ts
+++ b/test/ZNSPriceOracle.test.ts
@@ -1,0 +1,235 @@
+import * as hre from "hardhat";
+import { expect } from "chai";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { ZNSPriceOracle, ZNSPriceOracle__factory } from "../typechain";
+import { BigNumber } from "ethers";
+
+require("@nomicfoundation/hardhat-chai-matchers");
+
+describe("ZNSPriceOracle", () => {
+  let deployer: SignerWithAddress;
+  let user: SignerWithAddress;
+  let mockRegistrar: SignerWithAddress;
+  let contract: ZNSPriceOracle;
+  let factory: ZNSPriceOracle__factory;
+
+  const rootDomainPrice = hre.ethers.utils.parseEther("1");
+  const subdomainPrice = hre.ethers.utils.parseEther("0.2");
+
+  beforeEach(async () => {
+    [deployer, user, mockRegistrar] = await hre.ethers.getSigners();
+
+    factory = new ZNSPriceOracle__factory(deployer);
+    contract = await factory.deploy();
+
+    await contract.initialize(rootDomainPrice, subdomainPrice, mockRegistrar.address);
+  });
+
+  it("Confirms the mockRegistrar is authorized", async () => {
+    const authorized = await contract.isAuthorized(mockRegistrar.address);
+    expect(authorized).to.be.true;
+  });
+
+  it("Confirms the deployer is authorized", async () => {
+    const authorized = await contract.isAuthorized(deployer.address);
+    expect(authorized).to.be.true;
+  });
+
+  describe("getPrice", async () => {
+    it("Returns 0 price for a root or subdomain name with no length", async () => {
+      const priceRootDomain = await contract.getPrice(BigNumber.from("0"), true);
+      expect(priceRootDomain).to.eq(0);
+
+      const priceSubdomain = await contract.getPrice(BigNumber.from("0"), false);
+      expect(priceSubdomain).to.eq(0);
+    });
+
+    it("Returns the base price for domains that are equal to the base length", async () => {
+      // Using the default length of 3
+      const domain = "eth";
+
+      const rootPrice = await contract.rootDomainBasePrice();
+
+      const price = await contract.getPrice(domain.length, true);
+      expect(price).to.eq(rootPrice);
+    });
+
+    it("Returns the base price for subdomains that are equal to the base length", async () => {
+      const domain = "eth";
+
+      const subdomainPrice = await contract.subdomainBasePrice();
+
+      const price = await contract.getPrice(domain.length, false);
+      expect(price).to.eq(subdomainPrice);
+    });
+
+    it("Returns the base price for domains that are less than the base length", async () => {
+      const domainA = "et";
+      const domainB = "e";
+
+      const rootPrice = await contract.rootDomainBasePrice();
+
+      let priceRootDomain = await contract.getPrice(domainA.length, true);
+      expect(priceRootDomain).to.eq(rootPrice);
+
+      priceRootDomain = await contract.getPrice(domainB.length, true);
+      expect(priceRootDomain).to.eq(rootPrice);
+    });
+
+    it("Returns the base price for subdomains that are less than the base length", async () => {
+      const domainA = "et";
+      const domainB = "e";
+
+      const subdomainPrice = await contract.subdomainBasePrice();
+
+      let priceSubdomain = await contract.getPrice(domainA.length, false);
+      expect(priceSubdomain).to.eq(subdomainPrice);
+
+      priceSubdomain = await contract.getPrice(domainB.length, false);
+      expect(priceSubdomain).to.eq(subdomainPrice);
+    });
+
+    it("Returns the expected price for a domain greater than the base length", async () => {
+      const domain = "wilder";
+      const defaultRootPrice = await contract.rootDomainBasePrice();
+      const defaultMultiplier = await contract.priceMultiplier();
+
+      const expectedPrice = (defaultRootPrice.mul(defaultMultiplier)).div(domain.length).div(10);
+      const price = await contract.getPrice(domain.length, true);
+
+      expect(price).to.eq(expectedPrice);
+    });
+
+    it("Returns the expected price for a subdomain greater than the base length", async () => {
+      const domain = "wilder";
+      const defaultSubdomainPrice = await contract.subdomainBasePrice();
+      const defaultMultiplier = await contract.priceMultiplier();
+
+      const expectedPrice = (defaultSubdomainPrice.mul(defaultMultiplier)).div(domain.length).div(10);
+      const price = await contract.getPrice(domain.length, false);
+
+      expect(price).to.eq(expectedPrice);
+    });
+
+    it("Returns a price even if the domain name is very long", async () => {
+      // 255 length
+      const domain = `abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz` +
+        `abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz` +
+        `abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz` +
+        `abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz` +
+        `abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstu`;
+
+      const defaultRootPrice = await contract.rootDomainBasePrice();
+      const defaultMultiplier = await contract.priceMultiplier();
+
+      const expectedPrice = (defaultRootPrice.mul(defaultMultiplier)).div(domain.length).div(10);
+      const price = await contract.getPrice(domain.length, true);
+
+      expect(price).to.eq(expectedPrice);
+    });
+  });
+
+  describe("setBasePrice", () => {
+    it("Allows an authorized user to set the base price", async () => {
+      const newBasePrice = hre.ethers.utils.parseEther("0.7");
+
+      await contract.connect(deployer).setBasePrice(newBasePrice, true);
+
+      const updatedBasePrice = await contract.rootDomainBasePrice();
+      expect(updatedBasePrice).to.eq(newBasePrice);
+    });
+
+    it("Disallows an unauthorized user to set the base price", async () => {
+      const newBasePrice = hre.ethers.utils.parseEther("0.7");
+
+      const tx = contract.connect(user).setBasePrice(newBasePrice, true);
+      expect(tx).to.be.revertedWith("ZNS: Not allowed")
+    });
+
+    it("Allows setting the price to zero", async () => {
+      const newBasePrice = BigNumber.from("0");
+
+      await contract.connect(deployer).setBasePrice(newBasePrice, true);
+
+      const updatedBasePrice = await contract.rootDomainBasePrice();
+      expect(updatedBasePrice).to.eq(newBasePrice);
+    });
+  });
+
+  describe("setPriceMultiplier", () => {
+    it("Allows an authorized user to set the price multiplier", async () => {
+      const newMultiplier = BigNumber.from("25");
+
+      await contract.connect(deployer).setPriceMultipler(newMultiplier);
+
+      const updatedMultiplier = await contract.priceMultiplier();
+      expect(updatedMultiplier).to.eq(newMultiplier);
+    });
+
+    it("Disallows an unauthorized user to set the base price", async () => {
+      const newMultiplier = BigNumber.from("25");
+
+      const tx = contract.connect(user).setPriceMultipler(newMultiplier);
+      expect(tx).to.be.revertedWith("ZNS: Not allowed")
+    });
+
+    it("Allows setting the multiplier to zero", async () => {
+      const newMultiplier = BigNumber.from("0");
+
+      await contract.connect(deployer).setPriceMultipler(newMultiplier);
+
+      const updatedMultiplier = await contract.priceMultiplier();
+      expect(updatedMultiplier).to.eq(newMultiplier);
+    });
+  });
+
+  describe("setBaseLength", () => {
+    it("Allows an authorized user to set the length boundary", async () => {
+      const newBoundary = 5;
+
+      await contract.connect(deployer).setBaseLength(newBoundary);
+
+      const updatedBoundary = await contract.baseLength();
+      expect(updatedBoundary).to.eq(newBoundary);
+    });
+
+    it("Disallows an unauthorized user to set the base price", async () => {
+      const newBoundary = 5;
+
+      const tx = contract.connect(user).setBaseLength(newBoundary);
+      expect(tx).to.be.revertedWith("ZNS: Not allowed")
+    });
+
+    it("Allows setting the boundary to zero", async () => {
+      const newBoundary = 0;
+
+      await contract.connect(deployer).setBaseLength(newBoundary);
+
+      const updatedBoundary = await contract.baseLength();
+      expect(updatedBoundary).to.eq(newBoundary);
+    });
+  });
+
+  describe("Events", () => {
+    it("Emits BasePriceSet", async () => {
+      const newBasePrice = hre.ethers.utils.parseEther("0.7");
+
+      const tx = contract.connect(deployer).setBasePrice(newBasePrice, true);
+      await expect(tx).to.emit(contract, "BasePriceSet").withArgs(newBasePrice, true);
+    });
+
+    it("Emits PriceMultiplierSet", async () => {
+      const newMultiplier = BigNumber.from("25");
+
+      const tx = contract.connect(deployer).setPriceMultipler(newMultiplier);
+      await expect(tx).to.emit(contract, "PriceMultiplierSet").withArgs(newMultiplier);
+    });
+
+    it("Emits BaseLengthSet", async () => {
+      const newLength = 5;
+
+      const tx = contract.connect(deployer).setBaseLength(newLength);
+      await expect(tx).to.emit(contract, "BaseLengthSet").withArgs(newLength);
+    });
+  });
+});

--- a/test/ZNSRegistry.test.ts
+++ b/test/ZNSRegistry.test.ts
@@ -14,12 +14,12 @@ require('@nomicfoundation/hardhat-chai-matchers');
  */
 
 describe('ZNSRegistry Tests', () => {
-  let deployer : SignerWithAddress;
-  let operator : SignerWithAddress;
+  let deployer: SignerWithAddress;
+  let operator: SignerWithAddress;
 
   // ZNSResolver has not been created, but an address will be equivalent for now
-  let mockResolver : SignerWithAddress;
-  let registry : ZNSRegistry;
+  let mockResolver: SignerWithAddress;
+  let registry: ZNSRegistry;
 
   // Set owner of 0x0 domain in initalizer, will be used by every other subdomain
   const rootDomainHash = hre.ethers.constants.HashZero;

--- a/test/ZNSRegistry.test.ts
+++ b/test/ZNSRegistry.test.ts
@@ -14,13 +14,13 @@ require("@nomicfoundation/hardhat-chai-matchers");
  */
 
 describe("ZNSRegistry Tests", () => {
-  let deployer: SignerWithAddress;
-  let operator: SignerWithAddress;
-  let randomUser: SignerWithAddress;
+  let deployer : SignerWithAddress;
+  let operator : SignerWithAddress;
+  let randomUser : SignerWithAddress;
 
   // ZNSResolver has not been created, but an address will be equivalent for now
-  let mockResolver: SignerWithAddress;
-  let registry: ZNSRegistry;
+  let mockResolver : SignerWithAddress;
+  let registry : ZNSRegistry;
 
   // Set owner of 0x0 domain in initalizer, will be used by every other subdomain
   const rootDomainHash = hre.ethers.constants.HashZero;

--- a/test/ZNSRegistry.test.ts
+++ b/test/ZNSRegistry.test.ts
@@ -1,9 +1,9 @@
-import * as hre from 'hardhat';
-import { expect } from 'chai';
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
-import { ZNSRegistry, ZNSRegistry__factory } from '../typechain';
+import * as hre from "hardhat";
+import { expect } from "chai";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { ZNSRegistry, ZNSRegistry__factory } from "../typechain";
 
-require('@nomicfoundation/hardhat-chai-matchers');
+require("@nomicfoundation/hardhat-chai-matchers");
 
 /**
  * TODO should we disallow burning the root domain?
@@ -13,7 +13,7 @@ require('@nomicfoundation/hardhat-chai-matchers');
  * possibility the account is compromised
  */
 
-describe('ZNSRegistry Tests', () => {
+describe("ZNSRegistry Tests", () => {
   let deployer: SignerWithAddress;
   let operator: SignerWithAddress;
   let randomUser: SignerWithAddress;
@@ -24,12 +24,12 @@ describe('ZNSRegistry Tests', () => {
 
   // Set owner of 0x0 domain in initalizer, will be used by every other subdomain
   const rootDomainHash = hre.ethers.constants.HashZero;
-  const wilderLabel = hre.ethers.utils.id('wilder');
+  const wilderLabel = hre.ethers.utils.id("wilder");
 
   // Wilder subdomain hash created in `setSubdomainRecord` call to `setSubdomainOwner`
   // TODO:  change all the calls for hashing in all the tests to use ENS `namehash` lib
   //        that checks and validates strings before hashing
-  const wilderSubdomainHash = hre.ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], [rootDomainHash, wilderLabel]);
+  const wilderSubdomainHash = hre.ethers.utils.solidityKeccak256(["bytes32", "bytes32"], [rootDomainHash, wilderLabel]);
 
   beforeEach(async () => {
     [deployer, operator, randomUser, mockResolver] = await hre.ethers.getSigners();
@@ -51,62 +51,62 @@ describe('ZNSRegistry Tests', () => {
   });
 
   // a valid operator can change the owner of a domain, is this wanted?
-  describe('Operator functionality', () => {
-    it('Returns false when an operator is not allowed by an owner', async () => {
+  describe("Operator functionality", () => {
+    it("Returns false when an operator is not allowed by an owner", async () => {
       await registry.connect(deployer).setOwnerOperator(operator.address, false);
 
       const allowed = await registry.isAllowedOperator(deployer.address, operator.address);
       expect(allowed).to.be.false;
     });
 
-    it('Returns true when an operator is allowed by an owner', async () => {
+    it("Returns true when an operator is allowed by an owner", async () => {
       await registry.connect(deployer).setOwnerOperator(operator.address, true);
 
       const allowed = await registry.isAllowedOperator(deployer.address, operator.address);
       expect(allowed).to.be.true;
     });
 
-    it('Returns false when an owner has not specified any operators', async () => {
+    it("Returns false when an owner has not specified any operators", async () => {
       const allowed = await registry.isAllowedOperator(deployer.address, operator.address);
 
       expect(allowed).to.be.false;
     });
 
-    it('Permits an allowed operator to modify a domain record', async () => {
+    it("Permits an allowed operator to modify a domain record", async () => {
       await registry.connect(deployer).setOwnerOperator(operator.address, true);
 
       const tx = registry.connect(operator).setDomainResolver(wilderSubdomainHash, operator.address);
       await expect(tx).to.not.be.reverted;
     });
 
-    it('Does not permit a disallowed operator to modify a domain record', async () => {
+    it("Does not permit a disallowed operator to modify a domain record", async () => {
       await registry.connect(deployer).setOwnerOperator(operator.address, false);
 
       const tx = registry.connect(operator).setDomainResolver(wilderSubdomainHash, operator.address);
-      await expect(tx).to.be.revertedWith('ZNS: Not allowed');
+      await expect(tx).to.be.revertedWith("ZNS: Not allowed");
     });
 
-    it('Does not permit an operator that\'s never been allowed to modify a record', async () => {
+    it("Does not permit an operator that's never been allowed to modify a record", async () => {
       const tx = registry.connect(operator).setDomainResolver(wilderSubdomainHash, operator.address);
-      await expect(tx).to.be.revertedWith('ZNS: Not allowed');
+      await expect(tx).to.be.revertedWith("ZNS: Not allowed");
     });
   });
 
-  describe('Domain and subdomain records', async () => {
-    it('Checks existence of a domain correctly', async () => {
+  describe("Domain and subdomain records", async () => {
+    it("Checks existence of a domain correctly", async () => {
       const exists = await registry.connect(randomUser).exists(wilderSubdomainHash);
       expect(exists).to.be.true;
 
       const nonExistentDomainHash = hre.ethers.utils
         .solidityKeccak256(
-          ['bytes32'],
-          [hre.ethers.utils.id('wild')]
+          ["bytes32"],
+          [hre.ethers.utils.id("wild")]
         );
       const notExists = await registry.connect(randomUser).exists(nonExistentDomainHash);
       expect(notExists).to.be.false;
     });
 
-    it('Gets a domain record', async () => {
+    it("Gets a domain record", async () => {
       // Domain exists
       const rootRecord = await registry.getDomainRecord(rootDomainHash);
       expect(rootRecord.owner).to.eq(deployer.address);
@@ -116,51 +116,51 @@ describe('ZNSRegistry Tests', () => {
       expect(wilderRecord.owner).to.eq(deployer.address);
 
       // Domain does not exist
-      const domainHash = hre.ethers.utils.id('random-record');
+      const domainHash = hre.ethers.utils.id("random-record");
       const record = await registry.getDomainRecord(domainHash);
       expect(record.owner).to.eq(hre.ethers.constants.AddressZero);
     });
 
-    it('Gets a domain owner', async () => {
+    it("Gets a domain owner", async () => {
       // The domain exists
       const existOwner = await registry.getDomainOwner(wilderSubdomainHash);
       expect(existOwner).to.eq(deployer.address);
 
       // The domain does not exist
-      const domainHash = hre.ethers.utils.id('random-record');
+      const domainHash = hre.ethers.utils.id("random-record");
       const notExistOwner = await registry.getDomainOwner(domainHash);
       expect(notExistOwner).to.eq(hre.ethers.constants.AddressZero);
     });
 
-    it('Gets a domain resolver', async () => {
+    it("Gets a domain resolver", async () => {
       // The domain exists
       const existResolver = await registry.getDomainResolver(wilderSubdomainHash);
       expect(existResolver).to.eq(mockResolver.address);
 
       // The domain does not exist
-      const domainHash = hre.ethers.utils.id('random-record');
+      const domainHash = hre.ethers.utils.id("random-record");
       const notExistResolver = await registry.getDomainResolver(domainHash);
       expect(notExistResolver).to.eq(hre.ethers.constants.AddressZero);
 
     });
   });
 
-  describe('Setter functions for a domain\'s record, owner, or resolver', () => {
-    it('Sets a domain record', async () => {
+  describe("Setter functions for a domain's record, owner, or resolver", () => {
+    it("Sets a domain record", async () => {
       await registry.connect(deployer).setDomainRecord(rootDomainHash, operator.address, mockResolver.address);
 
       const record = await registry.getDomainRecord(rootDomainHash);
       expect(record.owner).to.eq(operator.address);
     });
 
-    it('Fails to set a record when caller is not owner or operator', async () => {
+    it("Fails to set a record when caller is not owner or operator", async () => {
       const tx = registry.connect(operator).setDomainRecord(rootDomainHash, operator.address, mockResolver.address);
-      await expect(tx).to.be.revertedWith('ZNS: Not allowed');
+      await expect(tx).to.be.revertedWith("ZNS: Not allowed");
     });
 
-    it('Sets a subdomain record', async () => {
+    it("Sets a subdomain record", async () => {
       // In order to set a subdomain, the caller must be the owner of the parent domain
-      const zeroLabel = hre.ethers.utils.id('zero');
+      const zeroLabel = hre.ethers.utils.id("zero");
 
       await registry.connect(deployer)
         .setSubdomainRecord(
@@ -172,15 +172,15 @@ describe('ZNSRegistry Tests', () => {
 
       const zeroDomainHash = hre.ethers.utils
         .solidityKeccak256(
-          ['bytes32', 'bytes32'],
+          ["bytes32", "bytes32"],
           [wilderSubdomainHash, zeroLabel]
         );
       const zeroOwner = await registry.getDomainOwner(zeroDomainHash);
       expect(zeroOwner).to.eq(deployer.address);
     });
 
-    it('Fails to set a subdomain record because caller is not the owner of the parent domain', async () => {
-      const zeroLabel = hre.ethers.utils.id('zero');
+    it("Fails to set a subdomain record because caller is not the owner of the parent domain", async () => {
+      const zeroLabel = hre.ethers.utils.id("zero");
 
       const tx = registry.connect(operator)
         .setSubdomainRecord(
@@ -189,21 +189,21 @@ describe('ZNSRegistry Tests', () => {
           deployer.address,
           mockResolver.address
         );
-      await expect(tx).to.be.revertedWith('ZNS: Not allowed');
+      await expect(tx).to.be.revertedWith("ZNS: Not allowed");
     });
 
-    it('Fails to create another root domain', async () => {
+    it("Fails to create another root domain", async () => {
       // The root domain ownership is set in the initializer function
       // Any additional root domains would fail because they are checked for owner,
       // but because that owner can't exist as the record doesn't exist yet, it fails
-      const domainHash = hre.ethers.utils.id('random-record');
+      const domainHash = hre.ethers.utils.id("random-record");
       const tx = registry.connect(deployer)
         .setDomainRecord(
           domainHash,
           operator.address,
           mockResolver.address
         );
-      await expect(tx).to.be.revertedWith('ZNS: Not allowed');
+      await expect(tx).to.be.revertedWith("ZNS: Not allowed");
     });
   });
 });

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -5,17 +5,31 @@ import { ZNSPriceOracle } from "../../typechain";
  * Helper function to get the domain name price base on its length when given
  * an already deployed contract
  *
- * @param length Length of the domain name
+ * @param name Length of the domain name
  * @param contract The deployer ZNSPriceOracle contract
  */
-export const getPrice = async (length: number, contract: ZNSPriceOracle, isRootDomain: boolean): Promise<BigNumber> => {
+export const getPrice = async (
+  name : string,
+  contract : ZNSPriceOracle,
+  isRootDomain : boolean
+) : Promise<BigNumber> => {
 
-  const basePrice = isRootDomain ? await contract.rootDomainBasePrice() : await contract.subdomainBasePrice();
-  const baseLength = await contract.baseLength();
+  const basePrice = isRootDomain
+    ? await contract.rootDomainBasePrice()
+    : await contract.subdomainBasePrice();
+
+  const baseLength = isRootDomain
+    ? await contract.rootDomainBaseLength()
+    : await contract.subdomainBaseLength();
+
+  if (name.length <= baseLength) {
+    return basePrice;
+  }
+
   const multiplier = await contract.priceMultiplier();
 
   const numerator = basePrice.mul(baseLength).mul(multiplier);
-  const denominator = length + (3 * multiplier);
+  const denominator = (multiplier.mul(3).add(name.length));
 
   const expectedPrice = numerator.div(denominator).div(100);
   return expectedPrice;

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -10,9 +10,13 @@ import { ZNSPriceOracle } from "../../typechain";
  */
 export const getPrice = async (length: number, contract: ZNSPriceOracle, isRootDomain: boolean): Promise<BigNumber> => {
 
-  const defaultPrice = isRootDomain ? await contract.rootDomainBasePrice() : await contract.subdomainBasePrice();
-  const defaultMultiplier = await contract.priceMultiplier();
+  const basePrice = isRootDomain ? await contract.rootDomainBasePrice() : await contract.subdomainBasePrice();
+  const baseLength = await contract.baseLength();
+  const multiplier = await contract.priceMultiplier();
 
-  const expectedPrice = (defaultPrice.mul(defaultMultiplier)).div(length).div(10);
+  const numerator = basePrice.mul(baseLength).mul(multiplier);
+  const denominator = length + (3 * multiplier);
+
+  const expectedPrice = numerator.div(denominator).div(100);
   return expectedPrice;
 };

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -1,0 +1,18 @@
+import { BigNumber } from "ethers";
+import { ZNSPriceOracle } from "../../typechain";
+
+/**
+ * Helper function to get the domain name price base on its length when given
+ * an already deployed contract
+ *
+ * @param length Length of the domain name
+ * @param contract The deployer ZNSPriceOracle contract
+ */
+export const getPrice = async (length: number, contract: ZNSPriceOracle, isRootDomain: boolean): Promise<BigNumber> => {
+
+  const defaultPrice = isRootDomain ? await contract.rootDomainBasePrice() : await contract.subdomainBasePrice();
+  const defaultMultiplier = await contract.priceMultiplier();
+
+  const expectedPrice = (defaultPrice.mul(defaultMultiplier)).div(length).div(10);
+  return expectedPrice;
+};

--- a/test/helpers/types.ts
+++ b/test/helpers/types.ts
@@ -3,9 +3,10 @@ import { BigNumber } from "ethers";
 export type Maybe<T> = T | undefined;
 
 export interface PriceOracleConfig {
-  rootDomainPrice: BigNumber;
-  subdomainPrice: BigNumber;
-  priceMultiplier: BigNumber;
-  baseLength: number;
-  registrarAddress: string;
+  rootDomainPrice : BigNumber;
+  subdomainPrice : BigNumber;
+  priceMultiplier : BigNumber;
+  rootDomainBaseLength : number;
+  subdomainBaseLength : number;
+  registrarAddress : string;
 }

--- a/test/helpers/types.ts
+++ b/test/helpers/types.ts
@@ -1,0 +1,11 @@
+import { BigNumber } from "ethers";
+
+export type Maybe<T> = T | undefined;
+
+export interface PriceOracleConfig {
+  rootDomainPrice: BigNumber;
+  subdomainPrice: BigNumber;
+  priceMultiplier: BigNumber;
+  baseLength: number;
+  registrarAddress: string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1803,10 +1803,10 @@
     "@typescript-eslint/types" "5.57.1"
     eslint-visitor-keys "^3.3.0"
 
-"@zero-tech/eslint-config-cpt@0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@zero-tech/eslint-config-cpt/-/eslint-config-cpt-0.2.4.tgz#4a1166b0e2fe4dfc5da1a84acc1df67cc11bcd56"
-  integrity sha512-rc5HpMS3QiGSvV/JbmuLUHKeXy7OEgZcHnueG0gbdvzaCmu3mohMoFjilP9y0c+3JmByUi2PoR3WmhMv+EkcSA==
+"@zero-tech/eslint-config-cpt@0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@zero-tech/eslint-config-cpt/-/eslint-config-cpt-0.2.5.tgz#0e963c7c4e9911813792ea8313fc6a098c4b9d05"
+  integrity sha512-XHtNAHULvfoz+S1Zr63JLYb5S+8NZOp5bBAv4SmECPrcHpaqO7NiJ/qU1YUJwASGtqQK55CZhjyhjMittNgelA==
   dependencies:
     "@typescript-eslint/eslint-plugin" "^5.57.1"
     "@typescript-eslint/parser" "^5.57.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8251,6 +8251,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
+typescript-eslint@^0.0.1-alpha.0:
+  version "0.0.1-alpha.0"
+  resolved "https://registry.yarnpkg.com/typescript-eslint/-/typescript-eslint-0.0.1-alpha.0.tgz#285d68a4e96588295cd436278801bcb6a6b916c1"
+  integrity sha512-1hNKM37dAWML/2ltRXupOq2uqcdRQyDFphl+341NTPXFLLLiDhErXx8VtaSLh3xP7SyHZdcCgpt9boYYVb3fQg==
+
 typescript@^5.0.2:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.3.tgz#fe976f0c826a88d0a382007681cbb2da44afdedf"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8244,11 +8244,6 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript-eslint@^0.0.1-alpha.0:
-  version "0.0.1-alpha.0"
-  resolved "https://registry.yarnpkg.com/typescript-eslint/-/typescript-eslint-0.0.1-alpha.0.tgz#285d68a4e96588295cd436278801bcb6a6b916c1"
-  integrity sha512-1hNKM37dAWML/2ltRXupOq2uqcdRQyDFphl+341NTPXFLLLiDhErXx8VtaSLh3xP7SyHZdcCgpt9boYYVb3fQg==
-
 typescript@^5.0.2:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.3.tgz#fe976f0c826a88d0a382007681cbb2da44afdedf"


### PR DESCRIPTION
The ZNSPriceOracle contract allows ZNS to get the price of a domain based on the length of that domain. Two different base fees exist, one for root domains and one for subdomains. We call this the `basePrice`

Some amount of domains that are less than a certain length will all be the same, we call this a `baseLength`

There also exists a price multiplier we can use to modify how steep the price drop is in domain names from the initial base price. By default, this value is `3.9` because it forms a reasonable price decline.

We use a simple formula to calculate a domain's price: `(priceMultiplier * basePrice) / length`

Because no decimal values exist in Solidity, we increase by an order of 10 when storing the value for the multiplier and decrease by the same amount in the call to get a domain's price.

This is a visual of the curve of prices with a default `baseLength` of 3

![image](https://user-images.githubusercontent.com/5976499/230996259-b425fcaf-8441-45c2-bc3a-c0a7e7ba72c4.png)

