### PR TITLE
fix: Access Control #2 [WIP]

### DIFF
--- a/contracts/access/AccessControlled.sol
+++ b/contracts/access/AccessControlled.sol
@@ -16,16 +16,13 @@ abstract contract AccessControlled {
         _;
     }
 
-
     /**
-     * @dev This is here to make sure the external function is always implemented in children,
-     * otherwise we will not be able to reset the module.
+     * @dev These 2 virtual functions are here to make sure they are always implemented in children,
+     * otherwise we will not be able to reset the module or read the AC address
      */
-    function setAccessController(address _accessController) external virtual;
+    function getAccessController() external view virtual returns (address);
 
-    function getAccessController() external view returns (address) {
-        return address(accessController);
-    }
+    function setAccessController(address _accessController) external virtual;
 
     function _setAccessController(address _accessController) internal {
         require(_accessController != address(0), "AC: _accessController is 0x0 address");

--- a/contracts/access/AccessControlled.sol
+++ b/contracts/access/AccessControlled.sol
@@ -12,10 +12,7 @@ abstract contract AccessControlled {
 
 
     modifier onlyAdmin() {
-        require(
-            accessController.isAdmin(msg.sender),
-            "Caller is not an admin"
-        );
+        accessController.checkAdmin(msg.sender);
         _;
     }
 

--- a/contracts/access/AccessControlled.sol
+++ b/contracts/access/AccessControlled.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.18;
 
-import { ZNSRoles } from "./ZNSRoles.sol";
 import { IZNSAccessController } from "./IZNSAccessController.sol";
 
 
-abstract contract AccessControlled is ZNSRoles {
+abstract contract AccessControlled {
     event AccessControllerSet(address accessController);
 
     IZNSAccessController internal accessController;
 
+    // TODO AC: do we need this?
     modifier onlyRole(bytes32 role) {
         accessController.checkRole(role, msg.sender);
         _;

--- a/contracts/access/AccessControlled.sol
+++ b/contracts/access/AccessControlled.sol
@@ -19,9 +19,7 @@ abstract contract AccessControlled {
 
     /**
      * @dev This is here to make sure the external function is always implemented in children,
-     * otherwise we will not be able to reset the module (not ideal since it might
-     * not get to the final interface of a child).
-     * TODO AC: how do we make sure this gets to the final interface?
+     * otherwise we will not be able to reset the module.
      */
     function setAccessController(address _accessController) external virtual;
 

--- a/contracts/access/AccessControlled.sol
+++ b/contracts/access/AccessControlled.sol
@@ -5,9 +5,11 @@ import { IZNSAccessController } from "./IZNSAccessController.sol";
 
 
 abstract contract AccessControlled {
+
     event AccessControllerSet(address accessController);
 
     IZNSAccessController internal accessController;
+
 
     // TODO AC: do we need this?
     modifier onlyRole(bytes32 role) {

--- a/contracts/access/AccessControlled.sol
+++ b/contracts/access/AccessControlled.sol
@@ -16,6 +16,7 @@ abstract contract AccessControlled {
         _;
     }
 
+
     /**
      * @dev This is here to make sure the external function is always implemented in children,
      * otherwise we will not be able to reset the module (not ideal since it might

--- a/contracts/access/AccessControlled.sol
+++ b/contracts/access/AccessControlled.sol
@@ -11,9 +11,11 @@ abstract contract AccessControlled {
     IZNSAccessController internal accessController;
 
 
-    // TODO AC: do we need this?
-    modifier onlyRole(bytes32 role) {
-        accessController.checkRole(role, msg.sender);
+    modifier onlyAdmin() {
+        require(
+            accessController.isAdmin(msg.sender),
+            "Caller is not an admin"
+        );
         _;
     }
 

--- a/contracts/access/IZNSAccessController.sol
+++ b/contracts/access/IZNSAccessController.sol
@@ -10,8 +10,6 @@ interface IZNSAccessController is IAccessControlUpgradeable {
         address[] calldata operatorAddresses
     ) external;
 
-    function checkRole(bytes32 role, address account) external view;
-
     function setRoleAdmin(bytes32 role, bytes32 adminRole) external;
 
     function checkGovernor(address account) external view;

--- a/contracts/access/IZNSAccessController.sol
+++ b/contracts/access/IZNSAccessController.sol
@@ -21,4 +21,8 @@ interface IZNSAccessController is IAccessControlUpgradeable {
     function checkExecutor(address account) external view;
 
     function checkRegistrar(address account) external view;
+
+    function hasAdminRole(address account) external view returns (bool);
+
+    function hasRegistrarRole(address account) external view returns (bool);
 }

--- a/contracts/access/IZNSAccessController.sol
+++ b/contracts/access/IZNSAccessController.sol
@@ -14,5 +14,11 @@ interface IZNSAccessController is IAccessControlUpgradeable {
 
     function setRoleAdmin(bytes32 role, bytes32 adminRole) external;
 
-    function checkAdmin(address account) external view override;
+    function checkGovernor(address account) external view;
+
+    function checkAdmin(address account) external view;
+
+    function checkExecutor(address account) external view;
+
+    function checkRegistrar(address account) external view;
 }

--- a/contracts/access/IZNSAccessController.sol
+++ b/contracts/access/IZNSAccessController.sol
@@ -22,7 +22,7 @@ interface IZNSAccessController is IAccessControlUpgradeable {
 
     function checkRegistrar(address account) external view;
 
-    function hasAdminRole(address account) external view returns (bool);
+    function isAdmin(address account) external view returns (bool);
 
-    function hasRegistrarRole(address account) external view returns (bool);
+    function isRegistrar(address account) external view returns (bool);
 }

--- a/contracts/access/IZNSAccessController.sol
+++ b/contracts/access/IZNSAccessController.sol
@@ -13,4 +13,6 @@ interface IZNSAccessController is IAccessControlUpgradeable {
     function checkRole(bytes32 role, address account) external view;
 
     function setRoleAdmin(bytes32 role, bytes32 adminRole) external;
+
+    function isAdmin(address account) external view returns (bool);
 }

--- a/contracts/access/IZNSAccessController.sol
+++ b/contracts/access/IZNSAccessController.sol
@@ -14,5 +14,5 @@ interface IZNSAccessController is IAccessControlUpgradeable {
 
     function setRoleAdmin(bytes32 role, bytes32 adminRole) external;
 
-    function isAdmin(address account) external view returns (bool);
+    function checkAdmin(address account) external view override;
 }

--- a/contracts/access/ZNSAccessController.sol
+++ b/contracts/access/ZNSAccessController.sol
@@ -49,6 +49,14 @@ contract ZNSAccessController is AccessControlUpgradeable, ZNSRoles, IZNSAccessCo
         _checkRole(REGISTRAR_ROLE, account);
     }
 
+    function hasAdminRole(address account) external view override returns (bool) {
+        return hasRole(ADMIN_ROLE, account);
+    }
+
+    function hasRegistrarRole(address account) external view override returns (bool) {
+        return hasRole(REGISTRAR_ROLE, account);
+    }
+
     // TODO AC: is this function necessary? how often will it be used?
     function _grantRoleToMany(bytes32 role, address[] calldata addresses) internal {
         for (uint256 i = 0; i < addresses.length; i++) {

--- a/contracts/access/ZNSAccessController.sol
+++ b/contracts/access/ZNSAccessController.sol
@@ -31,6 +31,11 @@ contract ZNSAccessController is AccessControlUpgradeable, ZNSRoles, IZNSAccessCo
         _checkRole(role, account);
     }
 
+    function isAdmin(address account) external view override returns (bool) {
+        // TODO AC: use _checkRole() here??
+        return hasRole(ADMIN_ROLE, account);
+    }
+
     // TODO AC: is this function necessary? how often will it be used?
     function _grantRoleToMany(bytes32 role, address[] calldata addresses) internal {
         for (uint256 i = 0; i < addresses.length; i++) {

--- a/contracts/access/ZNSAccessController.sol
+++ b/contracts/access/ZNSAccessController.sol
@@ -31,8 +31,22 @@ contract ZNSAccessController is AccessControlUpgradeable, ZNSRoles, IZNSAccessCo
         _checkRole(role, account);
     }
 
+    // ** Access Validators **
+
+    function checkGovernor(address account) external view override {
+        _checkRole(GOVERNOR_ROLE, account);
+    }
+
     function checkAdmin(address account) external view override {
         _checkRole(ADMIN_ROLE, account);
+    }
+
+    function checkExecutor(address account) external view override {
+        _checkRole(EXECUTOR_ROLE, account);
+    }
+
+    function checkRegistrar(address account) external view override {
+        _checkRole(REGISTRAR_ROLE, account);
     }
 
     // TODO AC: is this function necessary? how often will it be used?

--- a/contracts/access/ZNSAccessController.sol
+++ b/contracts/access/ZNSAccessController.sol
@@ -31,9 +31,8 @@ contract ZNSAccessController is AccessControlUpgradeable, ZNSRoles, IZNSAccessCo
         _checkRole(role, account);
     }
 
-    function isAdmin(address account) external view override returns (bool) {
-        // TODO AC: use _checkRole() here??
-        return hasRole(ADMIN_ROLE, account);
+    function checkAdmin(address account) external view override {
+        _checkRole(ADMIN_ROLE, account);
     }
 
     // TODO AC: is this function necessary? how often will it be used?

--- a/contracts/access/ZNSAccessController.sol
+++ b/contracts/access/ZNSAccessController.sol
@@ -24,13 +24,6 @@ contract ZNSAccessController is AccessControlUpgradeable, ZNSRoles, IZNSAccessCo
         _setRoleAdmin(REGISTRAR_ROLE, ADMIN_ROLE);
     }
 
-    // TODO AC: should we keep this function here so that we can get standardized message?
-    //  test this function for gas usage with a standardized message vs a custom message
-    //  when using the recommended method of `hasRole`
-    function checkRole(bytes32 role, address account) external view override {
-        _checkRole(role, account);
-    }
-
     // ** Access Validators **
 
     function checkGovernor(address account) external view override {
@@ -49,11 +42,11 @@ contract ZNSAccessController is AccessControlUpgradeable, ZNSRoles, IZNSAccessCo
         _checkRole(REGISTRAR_ROLE, account);
     }
 
-    function hasAdminRole(address account) external view override returns (bool) {
+    function isAdmin(address account) external view override returns (bool) {
         return hasRole(ADMIN_ROLE, account);
     }
 
-    function hasRegistrarRole(address account) external view override returns (bool) {
+    function isRegistrar(address account) external view override returns (bool) {
         return hasRole(REGISTRAR_ROLE, account);
     }
 

--- a/contracts/access/ZNSAccessController.sol
+++ b/contracts/access/ZNSAccessController.sol
@@ -16,11 +16,11 @@ contract ZNSAccessController is AccessControlUpgradeable, ZNSRoles, IZNSAccessCo
         _grantRoleToMany(GOVERNOR_ROLE, governorAddresses);
         _grantRoleToMany(ADMIN_ROLE, adminAddresses);
 
-        // all of the governors control admins TODO AC: ???
+        // all of the governors control admins
         _setRoleAdmin(ADMIN_ROLE, GOVERNOR_ROLE);
-        // all of the governors control governors TODO AC: ???
+        // all of the governors control governors
         _setRoleAdmin(GOVERNOR_ROLE, GOVERNOR_ROLE);
-        // all of the admins control registrar TODO AC: ???
+        // all of the admins control registrar
         _setRoleAdmin(REGISTRAR_ROLE, ADMIN_ROLE);
     }
 
@@ -50,14 +50,12 @@ contract ZNSAccessController is AccessControlUpgradeable, ZNSRoles, IZNSAccessCo
         return hasRole(REGISTRAR_ROLE, account);
     }
 
-    // TODO AC: is this function necessary? how often will it be used?
     function _grantRoleToMany(bytes32 role, address[] calldata addresses) internal {
         for (uint256 i = 0; i < addresses.length; i++) {
             _grantRole(role, addresses[i]);
         }
     }
 
-    // TODO AC: how safe is this?
     function setRoleAdmin(bytes32 role, bytes32 adminRole) external override onlyRole(GOVERNOR_ROLE) {
         _setRoleAdmin(role, adminRole);
     }

--- a/contracts/access/ZNSRoles.sol
+++ b/contracts/access/ZNSRoles.sol
@@ -11,8 +11,7 @@ abstract contract ZNSRoles {
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
     // operator can be here to future proof, if we need a new role
     // so we don't have to upgrade all contracts
-    // TODO AC: change name of this role
-    bytes32 public constant OPERATOR_ROLE = keccak256("OPERATOR_ROLE");
+    bytes32 public constant EXECUTOR_ROLE = keccak256("EXECUTOR_ROLE");
     // this role is here specifically for the ZNSEthRegistrar contract
     bytes32 public constant REGISTRAR_ROLE = keccak256("REGISTRAR_ROLE");
     // TODO AC: what other roles do we need here?

--- a/contracts/access/ZNSRoles.sol
+++ b/contracts/access/ZNSRoles.sol
@@ -2,18 +2,16 @@
 pragma solidity ^0.8.18;
 
 
+// TODO: can we declare these outside of contract, just in the ZNSAccessController file?
 abstract contract ZNSRoles {
-    // TODO AC: test getting this from AC contract vs inheriting these roles in every other contract
-    // the highest rank, only assigns Admins
+    // the highest rank, assigns Admins, new roles and Role Admins
     bytes32 public constant GOVERNOR_ROLE = keccak256("GOVERNOR_ROLE");
     // the main maintainer role, that gets access to all system functions
-    // TODO AC: should we split responsibilities in a better way?
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
     // operator can be here to future proof, if we need a new role
     // so we don't have to upgrade all contracts
-    // TODO AC: decide what to do with this role
+    // TODO AC: possibly remove executor role?
     bytes32 public constant EXECUTOR_ROLE = keccak256("EXECUTOR_ROLE");
     // this role is here specifically for the ZNSEthRegistrar contract
     bytes32 public constant REGISTRAR_ROLE = keccak256("REGISTRAR_ROLE");
-    // TODO AC: what other roles do we need here?
 }

--- a/contracts/access/ZNSRoles.sol
+++ b/contracts/access/ZNSRoles.sol
@@ -11,6 +11,7 @@ abstract contract ZNSRoles {
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
     // operator can be here to future proof, if we need a new role
     // so we don't have to upgrade all contracts
+    // TODO AC: decide what to do with this role
     bytes32 public constant EXECUTOR_ROLE = keccak256("EXECUTOR_ROLE");
     // this role is here specifically for the ZNSEthRegistrar contract
     bytes32 public constant REGISTRAR_ROLE = keccak256("REGISTRAR_ROLE");

--- a/contracts/distribution/IZNSEthRegistrar.sol
+++ b/contracts/distribution/IZNSEthRegistrar.sol
@@ -18,14 +18,13 @@ interface IZNSEthRegistrar {
         address indexed registrant
     );
 
-    // TODO AC: remove ZNS from names here and in state vars
-    event ZnsRegistrySet(address znsRegistry);
+    event RegistrySet(address znsRegistry);
 
-    event ZnsTreasurySet(address znsTreasury);
+    event TreasurySet(address znsTreasury);
 
-    event ZnsDomainTokenSet(address znsDomainToken);
+    event DomainTokenSet(address znsDomainToken);
 
-    event ZnsAddressResolverSet(address znsAddressResolver);
+    event AddressResolverSet(address znsAddressResolver);
 
     function registerDomain(
         string calldata name,
@@ -36,13 +35,13 @@ interface IZNSEthRegistrar {
 
     function reclaimDomain(bytes32 domainHash) external;
 
-    function setZnsRegistry(address znsRegistry_) external;
+    function setRegistry(address znsRegistry_) external;
 
-    function setZnsTreasury(address znsTreasury_) external;
+    function setTreasury(address znsTreasury_) external;
 
-    function setZnsDomainToken(address znsDomainToken_) external;
+    function setDomainToken(address znsDomainToken_) external;
 
-    function setZnsAddressResolver(address znsAddressResolver_) external;
+    function setAddressResolver(address znsAddressResolver_) external;
 
     function setAccessController(address accessController_) external;
 }

--- a/contracts/distribution/IZNSEthRegistrar.sol
+++ b/contracts/distribution/IZNSEthRegistrar.sol
@@ -44,4 +44,6 @@ interface IZNSEthRegistrar {
     function setAddressResolver(address znsAddressResolver_) external;
 
     function setAccessController(address accessController_) external;
+
+    function getAccessController() external view returns (address);
 }

--- a/contracts/distribution/IZNSPriceOracle.sol
+++ b/contracts/distribution/IZNSPriceOracle.sol
@@ -122,4 +122,6 @@ interface IZNSPriceOracle {
     function setBaseLengths(uint256 rootLength, uint256 subdomainLength) external;
 
     function setAccessController(address accessController) external;
+
+    function getAccessController() external view returns (address);
 }

--- a/contracts/distribution/IZNSPriceOracle.sol
+++ b/contracts/distribution/IZNSPriceOracle.sol
@@ -120,4 +120,6 @@ interface IZNSPriceOracle {
      * @param subdomainLength The length for subdomains
      */
     function setBaseLengths(uint256 rootLength, uint256 subdomainLength) external;
+
+    function setAccessController(address accessController) external;
 }

--- a/contracts/distribution/IZNSTreasury.sol
+++ b/contracts/distribution/IZNSTreasury.sol
@@ -54,4 +54,6 @@ interface IZNSTreasury {
     function setPriceOracle(address znsPriceOracle_) external;
 
     function setStakingToken(address stakingToken_) external;
+
+    function setAccessController(address accessController) external;
 }

--- a/contracts/distribution/IZNSTreasury.sol
+++ b/contracts/distribution/IZNSTreasury.sol
@@ -3,12 +3,6 @@ pragma solidity ^0.8.18;
 
 interface IZNSTreasury {
     /**
-     * @notice Emitted when the znsRegistrar is updated
-     * @param znsRegistrar The address of the new registrar
-     */
-    event ZNSRegistrarSet(address znsRegistrar);
-
-    /**
      * @notice Emitted when a new stake is deposited
      * @param domainHash The hash of the domain name
      * @param domainName The domain name
@@ -36,7 +30,7 @@ interface IZNSTreasury {
 
     event ZnsPriceOracleSet(address znsPriceOracle);
 
-    event ZnsStakingTokenSet(address znsStakingToken);
+    event StakingTokenSet(address znsStakingToken);
 
     event ZeroVaultAddressSet(address zeroVault);
 

--- a/contracts/distribution/IZNSTreasury.sol
+++ b/contracts/distribution/IZNSTreasury.sol
@@ -28,7 +28,7 @@ interface IZNSTreasury {
         uint256 indexed amount
     );
 
-    event ZnsPriceOracleSet(address znsPriceOracle);
+    event PriceOracleSet(address znsPriceOracle);
 
     event StakingTokenSet(address znsStakingToken);
 

--- a/contracts/distribution/IZNSTreasury.sol
+++ b/contracts/distribution/IZNSTreasury.sol
@@ -50,4 +50,6 @@ interface IZNSTreasury {
     function setStakingToken(address stakingToken_) external;
 
     function setAccessController(address accessController) external;
+
+    function getAccessController() external view returns (address);
 }

--- a/contracts/distribution/ZNSEthRegistrar.sol
+++ b/contracts/distribution/ZNSEthRegistrar.sol
@@ -32,6 +32,15 @@ contract ZNSEthRegistrar is AccessControlled, IZNSEthRegistrar {
         _;
     }
 
+    // TODO AC: this might be the safest way
+    modifier onlyAdmin() {
+        require(
+            accessController.isAdmin(msg.sender),
+            "ZNSEthRegistrar: Caller is not an admin"
+        );
+        _;
+    }
+
     /**
      * @notice Create an instance of the ZNSEthRegistrar
      * for registering ZNS domains and subdomains
@@ -121,7 +130,7 @@ contract ZNSEthRegistrar is AccessControlled, IZNSEthRegistrar {
         emit DomainReclaimed(domainHash, msg.sender);
     }
 
-    function setZnsRegistry(address znsRegistry_) public override onlyRole(ADMIN_ROLE) {
+    function setZnsRegistry(address znsRegistry_) public override onlyAdmin {
         require(
             znsRegistry_ != address(0),
             "ZNSEthRegistrar: znsRegistry_ is 0x0 address"
@@ -131,7 +140,7 @@ contract ZNSEthRegistrar is AccessControlled, IZNSEthRegistrar {
         emit ZnsRegistrySet(znsRegistry_);
     }
 
-    function setZnsTreasury(address znsTreasury_) public override onlyRole(ADMIN_ROLE) {
+    function setZnsTreasury(address znsTreasury_) public override onlyAdmin {
         require(
             znsTreasury_ != address(0),
             "ZNSEthRegistrar: znsTreasury_ is 0x0 address"
@@ -141,7 +150,7 @@ contract ZNSEthRegistrar is AccessControlled, IZNSEthRegistrar {
         emit ZnsTreasurySet(znsTreasury_);
     }
 
-    function setZnsDomainToken(address znsDomainToken_) public override onlyRole(ADMIN_ROLE) {
+    function setZnsDomainToken(address znsDomainToken_) public override onlyAdmin {
         require(
             znsDomainToken_ != address(0),
             "ZNSEthRegistrar: znsDomainToken_ is 0x0 address"
@@ -151,7 +160,7 @@ contract ZNSEthRegistrar is AccessControlled, IZNSEthRegistrar {
         emit ZnsDomainTokenSet(znsDomainToken_);
     }
 
-    function setZnsAddressResolver(address znsAddressResolver_) public override onlyRole(ADMIN_ROLE) {
+    function setZnsAddressResolver(address znsAddressResolver_) public override onlyAdmin {
         require(
             znsAddressResolver_ != address(0),
             "ZNSEthRegistrar: znsAddressResolver_ is 0x0 address"
@@ -164,7 +173,7 @@ contract ZNSEthRegistrar is AccessControlled, IZNSEthRegistrar {
     function setAccessController(address accessController_)
     external
     override(AccessControlled, IZNSEthRegistrar)
-    onlyRole(ADMIN_ROLE)
+    onlyAdmin
     {
         _setAccessController(accessController_);
     }

--- a/contracts/distribution/ZNSEthRegistrar.sol
+++ b/contracts/distribution/ZNSEthRegistrar.sol
@@ -46,9 +46,10 @@ contract ZNSEthRegistrar is AccessControlled, IZNSEthRegistrar {
     ) {
         _setAccessController(accessController_);
         // TODO AC: should we call protected functions in the constructor/initialize?
+        //  test this!
         setRegistry(znsRegistry_);
         setTreasury(znsTreasury_);
-        setZnsDomainToken(znsDomainToken_);
+        setDomainToken(znsDomainToken_);
         setAddressResolver(znsAddressResolver_);
     }
 
@@ -142,7 +143,7 @@ contract ZNSEthRegistrar is AccessControlled, IZNSEthRegistrar {
         emit TreasurySet(znsTreasury_);
     }
 
-    function setZnsDomainToken(address znsDomainToken_) public override onlyAdmin {
+    function setDomainToken(address znsDomainToken_) public override onlyAdmin {
         require(
             znsDomainToken_ != address(0),
             "ZNSEthRegistrar: znsDomainToken_ is 0x0 address"

--- a/contracts/distribution/ZNSEthRegistrar.sol
+++ b/contracts/distribution/ZNSEthRegistrar.sol
@@ -8,6 +8,7 @@ import { IZNSDomainToken } from "../token/IZNSDomainToken.sol";
 import { IZNSAddressResolver } from "../resolver/IZNSAddressResolver.sol";
 import { AccessControlled } from "../access/AccessControlled.sol";
 
+
 contract ZNSEthRegistrar is AccessControlled, IZNSEthRegistrar {
 
     IZNSRegistry public znsRegistry;

--- a/contracts/distribution/ZNSEthRegistrar.sol
+++ b/contracts/distribution/ZNSEthRegistrar.sol
@@ -171,6 +171,10 @@ contract ZNSEthRegistrar is AccessControlled, IZNSEthRegistrar {
         _setAccessController(accessController_);
     }
 
+    function getAccessController() external view override(AccessControlled, IZNSEthRegistrar) returns (address) {
+        return address(accessController);
+    }
+
     /**
      * @notice Set domain data appropriately for a newly registered domain
      *

--- a/contracts/distribution/ZNSEthRegistrar.sol
+++ b/contracts/distribution/ZNSEthRegistrar.sol
@@ -28,7 +28,7 @@ contract ZNSEthRegistrar is AccessControlled, IZNSEthRegistrar {
     modifier onlyTokenOwner(bytes32 domainHash) {
         require(
             msg.sender == domainToken.ownerOf(uint256(domainHash)),
-            "ZNSEthRegistrar: Not the owner of the Token"
+            "ZNSEthRegistrar: Not the Owner of the Token"
         );
         _;
     }

--- a/contracts/distribution/ZNSEthRegistrar.sol
+++ b/contracts/distribution/ZNSEthRegistrar.sol
@@ -32,15 +32,6 @@ contract ZNSEthRegistrar is AccessControlled, IZNSEthRegistrar {
         _;
     }
 
-    // TODO AC: this might be the safest way
-    modifier onlyAdmin() {
-        require(
-            accessController.isAdmin(msg.sender),
-            "ZNSEthRegistrar: Caller is not an admin"
-        );
-        _;
-    }
-
     /**
      * @notice Create an instance of the ZNSEthRegistrar
      * for registering ZNS domains and subdomains

--- a/contracts/distribution/ZNSEthRegistrar.sol
+++ b/contracts/distribution/ZNSEthRegistrar.sol
@@ -45,8 +45,6 @@ contract ZNSEthRegistrar is AccessControlled, IZNSEthRegistrar {
         address znsAddressResolver_
     ) {
         _setAccessController(accessController_);
-        // TODO AC: should we call protected functions in the constructor/initialize?
-        //  test this!
         setRegistry(znsRegistry_);
         setTreasury(znsTreasury_);
         setDomainToken(znsDomainToken_);

--- a/contracts/distribution/ZNSPriceOracle.sol
+++ b/contracts/distribution/ZNSPriceOracle.sol
@@ -7,6 +7,7 @@ import { IZNSPriceOracle } from "./IZNSPriceOracle.sol";
 import { StringUtils } from "../utils/StringUtils.sol";
 import { AccessControlled } from "../access/AccessControlled.sol";
 
+
 contract ZNSPriceOracle is AccessControlled, Initializable, IZNSPriceOracle {
     using StringUtils for string;
 
@@ -171,7 +172,7 @@ contract ZNSPriceOracle is AccessControlled, Initializable, IZNSPriceOracle {
 
     function setAccessController(address accessController)
     external
-    override
+    override(IZNSPriceOracle, AccessControlled)
     onlyAdmin
     {
         _setAccessController(accessController);

--- a/contracts/distribution/ZNSPriceOracle.sol
+++ b/contracts/distribution/ZNSPriceOracle.sol
@@ -119,7 +119,7 @@ contract ZNSPriceOracle is AccessControlled, Initializable, IZNSPriceOracle {
     function setPriceMultiplier(uint256 multiplier) external override onlyAdmin {
         require(
             multiplier >= 300 && multiplier <= 400,
-            "ZNS: Multiplier out of range"
+            "ZNSPriceOracle: Multiplier out of range"
         );
         priceConfig.priceMultiplier = multiplier;
 

--- a/contracts/distribution/ZNSPriceOracle.sol
+++ b/contracts/distribution/ZNSPriceOracle.sol
@@ -178,6 +178,10 @@ contract ZNSPriceOracle is AccessControlled, Initializable, IZNSPriceOracle {
         _setAccessController(accessController);
     }
 
+    function getAccessController() external view override(AccessControlled, IZNSPriceOracle) returns (address) {
+        return address(accessController);
+    }
+
     /**
      * @notice Internal function to get price abstract of the base price being for
      * a root domain or a subdomain.

--- a/contracts/distribution/ZNSPriceOracle.sol
+++ b/contracts/distribution/ZNSPriceOracle.sol
@@ -172,7 +172,7 @@ contract ZNSPriceOracle is AccessControlled, Initializable, IZNSPriceOracle {
 
     function setAccessController(address accessController)
     external
-    override(IZNSPriceOracle, AccessControlled)
+    override(AccessControlled, IZNSPriceOracle)
     onlyAdmin
     {
         _setAccessController(accessController);

--- a/contracts/distribution/ZNSPriceOracle.sol
+++ b/contracts/distribution/ZNSPriceOracle.sol
@@ -7,7 +7,7 @@ import { IZNSPriceOracle } from "./IZNSPriceOracle.sol";
 import { StringUtils } from "../utils/StringUtils.sol";
 import { AccessControlled } from "../access/AccessControlled.sol";
 
-contract ZNSPriceOracle is AccessControlled, IZNSPriceOracle, Initializable {
+contract ZNSPriceOracle is AccessControlled, Initializable, IZNSPriceOracle {
     using StringUtils for string;
 
     uint256 public constant PERCENTAGE_BASIS = 10000;
@@ -90,7 +90,7 @@ contract ZNSPriceOracle is AccessControlled, IZNSPriceOracle, Initializable {
     function setMaxPrice(
         uint256 maxPrice,
         bool isRootDomain
-    ) external override onlyRole(ADMIN_ROLE) {
+    ) external override onlyAdmin {
         if (isRootDomain) {
             priceConfig.maxRootDomainPrice = maxPrice;
         } else {
@@ -113,7 +113,7 @@ contract ZNSPriceOracle is AccessControlled, IZNSPriceOracle, Initializable {
      * to make up for this.
      * @param multiplier The new price multiplier to set
      */
-    function setPriceMultiplier(uint256 multiplier) external override onlyRole(ADMIN_ROLE) {
+    function setPriceMultiplier(uint256 multiplier) external override onlyAdmin {
         require(
             multiplier >= 300 && multiplier <= 400,
             "ZNS: Multiplier out of range"
@@ -123,7 +123,11 @@ contract ZNSPriceOracle is AccessControlled, IZNSPriceOracle, Initializable {
         emit PriceMultiplierSet(multiplier);
     }
 
-    function setRegistrationFeePercentage(uint256 regFeePercentage) external override onlyRole(ADMIN_ROLE) {
+    function setRegistrationFeePercentage(uint256 regFeePercentage)
+    external
+    override
+    onlyAdmin
+    {
         feePercentage = regFeePercentage;
         emit FeePercentageSet(regFeePercentage);
     }
@@ -138,7 +142,7 @@ contract ZNSPriceOracle is AccessControlled, IZNSPriceOracle, Initializable {
     function setBaseLength(
         uint256 length,
         bool isRootDomain
-    ) external override onlyRole(ADMIN_ROLE) {
+    ) external override onlyAdmin {
         if (isRootDomain) {
             priceConfig.baseRootDomainLength = length;
         } else {
@@ -156,14 +160,18 @@ contract ZNSPriceOracle is AccessControlled, IZNSPriceOracle, Initializable {
     function setBaseLengths(
         uint256 rootLength,
         uint256 subdomainLength
-    ) external override onlyRole(ADMIN_ROLE) {
+    ) external override onlyAdmin {
         priceConfig.baseRootDomainLength = rootLength;
         priceConfig.baseSubdomainLength = subdomainLength;
 
         emit BaseLengthsSet(rootLength, subdomainLength);
     }
 
-    function setAccessController(address accessController) external override onlyRole(ADMIN_ROLE) {
+    function setAccessController(address accessController)
+    external
+    override
+    onlyAdmin
+    {
         _setAccessController(accessController);
     }
 

--- a/contracts/distribution/ZNSPriceOracle.sol
+++ b/contracts/distribution/ZNSPriceOracle.sol
@@ -25,16 +25,18 @@ contract ZNSPriceOracle is AccessControlled, Initializable, IZNSPriceOracle {
     // TODO: rework and add more setters for every single var
     PriceParams public priceConfig;
 
+    // TODO: rework setters here for a better structure!
+    // TODO: remove subdomain logic
 
     function initialize(
         address accessController_,
         PriceParams calldata priceConfig_,
         uint256 regFeePercentage_
     ) public override initializer {
+        _setAccessController(accessController_);
         // Set pricing and length parameters
         priceConfig = priceConfig_;
         feePercentage = regFeePercentage_;
-        _setAccessController(accessController_);
     }
 
     /**

--- a/contracts/distribution/ZNSTreasury.sol
+++ b/contracts/distribution/ZNSTreasury.sol
@@ -44,7 +44,7 @@ contract ZNSTreasury is AccessControlled, IZNSTreasury {
         address stakingToken_,
         address zeroVault_
     ) {
-        setAccessController(accessController_);
+        _setAccessController(accessController_);
         setZeroVaultAddress(zeroVault_);
         // TODO change from mock
         setStakingToken(stakingToken_);

--- a/contracts/distribution/ZNSTreasury.sol
+++ b/contracts/distribution/ZNSTreasury.sol
@@ -115,7 +115,7 @@ contract ZNSTreasury is AccessControlled, IZNSTreasury {
 
     function setAccessController(address accessController_)
     public
-    override
+    override(IZNSTreasury, AccessControlled)
     onlyAdmin
     {
         _setAccessController(accessController_);

--- a/contracts/distribution/ZNSTreasury.sol
+++ b/contracts/distribution/ZNSTreasury.sol
@@ -115,7 +115,7 @@ contract ZNSTreasury is AccessControlled, IZNSTreasury {
 
     function setAccessController(address accessController_)
     public
-    override(IZNSTreasury, AccessControlled)
+    override(AccessControlled, IZNSTreasury)
     onlyAdmin
     {
         _setAccessController(accessController_);

--- a/contracts/distribution/ZNSTreasury.sol
+++ b/contracts/distribution/ZNSTreasury.sol
@@ -95,7 +95,6 @@ contract ZNSTreasury is AccessControlled, IZNSTreasury {
         emit ZeroVaultAddressSet(zeroVaultAddress);
     }
 
-    // TODO AC: should we call a protected function in the constructor/initialize?
     function setPriceOracle(address znsPriceOracle_) public override onlyAdmin {
         require(
             znsPriceOracle_ != address(0),

--- a/contracts/distribution/ZNSTreasury.sol
+++ b/contracts/distribution/ZNSTreasury.sol
@@ -32,14 +32,20 @@ contract ZNSTreasury is AccessControlled, IZNSTreasury {
     mapping(bytes32 domainHash => uint256 amountStaked) public stakedForDomain;
 
 
+    modifier onlyRegistrar() {
+        accessController.checkRegistrar(msg.sender);
+        _;
+    }
+
+
     constructor(
         address accessController_,
         address znsPriceOracle_,
         address stakingToken_,
         address zeroVault_
     ) {
-        _setAccessController(accessController_);
-        _setZeroVaultAddress(zeroVault_);
+        setAccessController(accessController_);
+        setZeroVaultAddress(zeroVault_);
         // TODO change from mock
         setStakingToken(stakingToken_);
         setPriceOracle(znsPriceOracle_);
@@ -50,7 +56,7 @@ contract ZNSTreasury is AccessControlled, IZNSTreasury {
         string calldata domainName,
         address depositor,
         bool isTopLevelDomain
-    ) external override onlyRole(REGISTRAR_ROLE) {
+    ) external override onlyRegistrar {
         // Get price and fee for the domain
         (, uint256 stakeAmount, uint256 registrationFee) = znsPriceOracle.getPrice(
             domainName,
@@ -72,7 +78,7 @@ contract ZNSTreasury is AccessControlled, IZNSTreasury {
     function unstakeForDomain(
         bytes32 domainHash,
         address owner
-    ) external override onlyRole(REGISTRAR_ROLE) {
+    ) external override onlyRegistrar {
         uint256 stakeAmount = stakedForDomain[domainHash];
         require(stakeAmount > 0, "ZNSTreasury: No stake for domain");
         delete stakedForDomain[domainHash];
@@ -82,36 +88,36 @@ contract ZNSTreasury is AccessControlled, IZNSTreasury {
         emit StakeWithdrawn(domainHash, owner, stakeAmount);
     }
 
-    function setZeroVaultAddress(address zeroVaultAddress) external override onlyRole(ADMIN_ROLE) {
-        _setZeroVaultAddress(zeroVaultAddress);
+    function setZeroVaultAddress(address zeroVaultAddress) public override onlyAdmin {
+        require(zeroVaultAddress != address(0), "ZNSTreasury: zeroVault passed as 0x0 address");
+
+        zeroVault = zeroVaultAddress;
+        emit ZeroVaultAddressSet(zeroVaultAddress);
     }
 
     // TODO AC: should we call a protected function in the constructor/initialize?
-    function setPriceOracle(address znsPriceOracle_) public override onlyRole(ADMIN_ROLE) {
+    function setPriceOracle(address znsPriceOracle_) public override onlyAdmin {
         require(
             znsPriceOracle_ != address(0),
             "ZNSTreasury: znsPriceOracle_ passed as 0x0 address"
         );
 
-          znsPriceOracle = IZNSPriceOracle(znsPriceOracle_);
-          emit ZnsPriceOracleSet(znsPriceOracle_);
+        znsPriceOracle = IZNSPriceOracle(znsPriceOracle_);
+        emit ZnsPriceOracleSet(znsPriceOracle_);
     }
 
-    function setStakingToken(address stakingToken_) public override onlyRole(ADMIN_ROLE) {
+    function setStakingToken(address stakingToken_) public override onlyAdmin {
         require(stakingToken_ != address(0), "ZNSTreasury: stakingToken_ passed as 0x0 address");
 
         stakingToken = IERC20(stakingToken_);
         emit ZnsStakingTokenSet(stakingToken_);
     }
 
-    function setAccessController(address accessController_) external override onlyRole(ADMIN_ROLE) {
+    function setAccessController(address accessController_)
+    public
+    override
+    onlyAdmin
+    {
         _setAccessController(accessController_);
-    }
-
-    function _setZeroVaultAddress(address zeroVaultAddress) internal {
-        require(zeroVaultAddress != address(0), "ZNSTreasury: zeroVault passed as 0x0 address");
-
-        zeroVault = zeroVaultAddress;
-        emit ZeroVaultAddressSet(zeroVaultAddress);
     }
 }

--- a/contracts/distribution/ZNSTreasury.sol
+++ b/contracts/distribution/ZNSTreasury.sol
@@ -11,7 +11,7 @@ contract ZNSTreasury is AccessControlled, IZNSTreasury {
     /**
      * @notice The price oracle
      */
-    IZNSPriceOracle public znsPriceOracle;
+    IZNSPriceOracle public priceOracle;
 
     /**
      * @notice The payment/staking token
@@ -58,7 +58,7 @@ contract ZNSTreasury is AccessControlled, IZNSTreasury {
         bool isTopLevelDomain
     ) external override onlyRegistrar {
         // Get price and fee for the domain
-        (, uint256 stakeAmount, uint256 registrationFee) = znsPriceOracle.getPrice(
+        (, uint256 stakeAmount, uint256 registrationFee) = priceOracle.getPrice(
             domainName,
             isTopLevelDomain
         );
@@ -102,7 +102,7 @@ contract ZNSTreasury is AccessControlled, IZNSTreasury {
             "ZNSTreasury: znsPriceOracle_ passed as 0x0 address"
         );
 
-        znsPriceOracle = IZNSPriceOracle(znsPriceOracle_);
+        priceOracle = IZNSPriceOracle(znsPriceOracle_);
         emit ZnsPriceOracleSet(znsPriceOracle_);
     }
 
@@ -110,7 +110,7 @@ contract ZNSTreasury is AccessControlled, IZNSTreasury {
         require(stakingToken_ != address(0), "ZNSTreasury: stakingToken_ passed as 0x0 address");
 
         stakingToken = IERC20(stakingToken_);
-        emit ZnsStakingTokenSet(stakingToken_);
+        emit StakingTokenSet(stakingToken_);
     }
 
     function setAccessController(address accessController_)

--- a/contracts/distribution/ZNSTreasury.sol
+++ b/contracts/distribution/ZNSTreasury.sol
@@ -103,7 +103,7 @@ contract ZNSTreasury is AccessControlled, IZNSTreasury {
         );
 
         priceOracle = IZNSPriceOracle(znsPriceOracle_);
-        emit ZnsPriceOracleSet(znsPriceOracle_);
+        emit PriceOracleSet(znsPriceOracle_);
     }
 
     function setStakingToken(address stakingToken_) public override onlyAdmin {

--- a/contracts/distribution/ZNSTreasury.sol
+++ b/contracts/distribution/ZNSTreasury.sol
@@ -120,4 +120,8 @@ contract ZNSTreasury is AccessControlled, IZNSTreasury {
     {
         _setAccessController(accessController_);
     }
+
+    function getAccessController() external view override(AccessControlled, IZNSTreasury) returns (address) {
+        return address(accessController);
+    }
 }

--- a/contracts/registry/IZNSRegistry.sol
+++ b/contracts/registry/IZNSRegistry.sol
@@ -158,4 +158,6 @@ interface IZNSRegistry {
      * @param accessController The new access controller
      */
     function setAccessController(address accessController) external;
+
+    function getAccessController() external view returns (address);
 }

--- a/contracts/registry/IZNSRegistry.sol
+++ b/contracts/registry/IZNSRegistry.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.18;
 
 interface IZNSRegistry {
+
     /**
      * @notice The `DomainRecord` struct is meant to hold relevant information
      * about a domain, such as its owner and resolver.
@@ -10,6 +11,7 @@ interface IZNSRegistry {
         address owner;
         address resolver;
     }
+
     /**
      * @notice Emit when ownership of a domain is modified
      * @param owner The new domain owner
@@ -50,15 +52,11 @@ interface IZNSRegistry {
         bool allowed
     );
 
-    function initialize(address owner) external;
-
     /**
-     * @notice Emit when a new ZNSRegistrar address is set
-     * @param znsRegistrar The new address
+     * @notice Initialize the ZNSRegistry contract
+     * @param _accessController The address of the AccessController contract
      */
-    event ZNSRegistrarSet(
-        address indexed znsRegistrar
-    );
+    function initialize(address _accessController) external;
 
     /**
      * @notice Check if a given domain exists
@@ -79,7 +77,6 @@ interface IZNSRegistry {
     /**
      * @notice Set an `operator` as `allowed` to give or remove permissions for all
      * domains owned by `msg.sender`
-     *
      * @param operator The account to allow/disallow
      * @param allowed The true/false value to set
      */
@@ -111,7 +108,6 @@ interface IZNSRegistry {
 
     /**
      * @notice Create a new domain record
-     *
      * @param domainHash The hash of the domain name
      * @param owner The owner of the new domain
      * @param resolver The resolver of the new domain
@@ -124,7 +120,6 @@ interface IZNSRegistry {
 
     /**
      * @notice Update an existing domain record's owner or resolver
-     *
      * @param domainHash The hash of the domain
      * @param owner The owner or an allowed operator of that domain
      * @param resolver The resolver for the domain
@@ -144,7 +139,6 @@ interface IZNSRegistry {
 
     /**
      * @notice Update the domain's default resolver
-     *
      * @param domainHash the hash of a domain's name
      * @param resolver The new default resolver
      */
@@ -154,16 +148,14 @@ interface IZNSRegistry {
     ) external;
 
     /**
-     * @notice Change the address of the ZNSRegistrar contract we use
-     *
-     * @param znsRegistrar_ The new ZNSRegistrar
-     */
-    function setZNSRegistrar(address znsRegistrar_) external;
-
-    /**
      * @notice Delete a domain's record
-     *
      * @param domainHash The hash of the domain name
      */
     function deleteRecord(bytes32 domainHash) external;
+
+    /**
+     * @notice Set the access controller contract
+     * @param accessController The new access controller
+     */
+    function setAccessController(address accessController) external;
 }

--- a/contracts/registry/ZNSRegistry.sol
+++ b/contracts/registry/ZNSRegistry.sol
@@ -11,11 +11,6 @@ import { AccessControlled } from "../access/AccessControlled.sol";
 contract ZNSRegistry is AccessControlled, ERC1967UpgradeUpgradeable, IZNSRegistry {
 
     /**
-     * @notice The address of the registrar we are using
-     */
-    address public znsRegistrar;
-
-    /**
      * @notice Mapping `domainHash` to `DomainRecord` struct to hold information
      * about each domain
      */
@@ -54,10 +49,16 @@ contract ZNSRegistry is AccessControlled, ERC1967UpgradeUpgradeable, IZNSRegistr
         _;
     }
 
+    /**
+     * @notice Initialize the ZNSRegistry contract
+     * @param _accessController The address of the AccessController contract
+     */
+    function initialize(address _accessController) public override initializer {
+        _setAccessController(_accessController);
+    }
 
     /**
      * @notice Check if a given domain exists
-     *
      * @param domainHash The hash of a domain's name
      */
     function exists(bytes32 domainHash) external view override returns (bool) {
@@ -66,7 +67,6 @@ contract ZNSRegistry is AccessControlled, ERC1967UpgradeUpgradeable, IZNSRegistr
 
     /**
      * @notice Checks if provided address is an owner or an operator of the provided domain
-     *
      * @param domainHash The hash of a domain's name
      * @param candidate The address for which we are checking access
      */
@@ -81,7 +81,6 @@ contract ZNSRegistry is AccessControlled, ERC1967UpgradeUpgradeable, IZNSRegistr
     /**
      * @notice Set an `operator` as `allowed` to give or remove permissions for all
      * domains owned by the owner `msg.sender`
-     *
      * @param operator The account to allow/disallow
      * @param allowed The true/false value to set
      */
@@ -93,7 +92,6 @@ contract ZNSRegistry is AccessControlled, ERC1967UpgradeUpgradeable, IZNSRegistr
 
     /**
      * @notice Get a record for a domain
-     *
      * @param domainHash the hash of a domain's name
      */
     function getDomainRecord(
@@ -104,7 +102,6 @@ contract ZNSRegistry is AccessControlled, ERC1967UpgradeUpgradeable, IZNSRegistr
 
     /**
      * @notice Get the owner of the given domain
-     *
      * @param domainHash the hash of a domain's name
      */
     function getDomainOwner(
@@ -115,7 +112,6 @@ contract ZNSRegistry is AccessControlled, ERC1967UpgradeUpgradeable, IZNSRegistr
 
     /**
      * @notice Get the default resolver for the given domain
-     *
      * @param domainHash the hash of a domain's name
      */
     function getDomainResolver(
@@ -126,7 +122,6 @@ contract ZNSRegistry is AccessControlled, ERC1967UpgradeUpgradeable, IZNSRegistr
 
     /**
      * @notice Create a new domain record
-     *
      * @param domainHash The hash of the domain name
      * @param owner The owner of the new domain
      * @param resolver The resolver of the new domain
@@ -146,7 +141,6 @@ contract ZNSRegistry is AccessControlled, ERC1967UpgradeUpgradeable, IZNSRegistr
 
     /**
      * @notice Update an existing domain record's owner or resolver
-     *
      * @param domainHash The hash of the domain
      * @param owner The owner or an allowed operator of that domain
      * @param resolver The resolver for the domain
@@ -163,7 +157,6 @@ contract ZNSRegistry is AccessControlled, ERC1967UpgradeUpgradeable, IZNSRegistr
 
     /**
      * @notice Update a domain's owner
-     *
      * @param domainHash the hash of a domain's name
      * @param owner The account to transfer ownership to
      */
@@ -177,7 +170,6 @@ contract ZNSRegistry is AccessControlled, ERC1967UpgradeUpgradeable, IZNSRegistr
 
     /**
      * @notice Update the domain's default resolver
-     *
      * @param domainHash the hash of a domain's name
      * @param resolver The new default resolver
      */
@@ -191,7 +183,6 @@ contract ZNSRegistry is AccessControlled, ERC1967UpgradeUpgradeable, IZNSRegistr
 
     /**
      * @notice Delete a domain's record
-     *
      * @param domainHash The hash of the domain name
      */
     function deleteRecord(bytes32 domainHash) external override onlyRegistrar {
@@ -200,9 +191,14 @@ contract ZNSRegistry is AccessControlled, ERC1967UpgradeUpgradeable, IZNSRegistr
         emit DomainRecordDeleted(domainHash);
     }
 
+    function setAccessController(
+        address accessController
+    ) external override(AccessControlled, IZNSRegistry) onlyAdmin {
+        _setAccessController(accessController);
+    }
+
     /**
      * @notice Check if a domain exists. True if the owner is not `0x0`
-     *
      * @param domainHash the hash of a domain's name
      */
     function _exists(bytes32 domainHash) internal view returns (bool) {
@@ -214,7 +210,6 @@ contract ZNSRegistry is AccessControlled, ERC1967UpgradeUpgradeable, IZNSRegistr
      * Note that we don't check for `address(0)` here. This is intentional
      * because we are not currently allowing reselling of domains and want
      * to enable burning them instead by transferring ownership to `address(0)`
-     *
      * @param domainHash the hash of a domain's name
      * @param owner The owner to set
      */
@@ -226,7 +221,6 @@ contract ZNSRegistry is AccessControlled, ERC1967UpgradeUpgradeable, IZNSRegistr
 
     /**
      * @notice Set a domain's resolver
-     *
      * @param domainHash the hash of a domain's name
      * @param resolver The resolver to set
      */

--- a/contracts/registry/ZNSRegistry.sol
+++ b/contracts/registry/ZNSRegistry.sol
@@ -205,6 +205,10 @@ contract ZNSRegistry is AccessControlled, ERC1967UpgradeUpgradeable, IZNSRegistr
         _setAccessController(accessController);
     }
 
+    function getAccessController() external view override(AccessControlled, IZNSRegistry) returns (address) {
+        return address(accessController);
+    }
+
     /**
      * @notice Check if a domain exists. True if the owner is not `0x0`
      * @param domainHash the hash of a domain's name

--- a/contracts/registry/ZNSRegistry.sol
+++ b/contracts/registry/ZNSRegistry.sol
@@ -168,7 +168,7 @@ contract ZNSRegistry is AccessControlled, ERC1967UpgradeUpgradeable, IZNSRegistr
         // this can be called from ZNSRegistrar as part of `reclaim()` flow
         require(
             msg.sender == records[domainHash].owner ||
-            accessController.hasRegistrarRole(msg.sender),
+            accessController.isRegistrar(msg.sender),
             "ZNSRegistry: Only Name Owner or Registrar allowed to call"
         );
 

--- a/contracts/resolver/IZNSAddressResolver.sol
+++ b/contracts/resolver/IZNSAddressResolver.sol
@@ -10,6 +10,12 @@ interface IZNSAddressResolver {
     event AddressSet(bytes32 indexed domainHash, address indexed newAddress);
 
     /**
+     * @dev Emit when the registry is set
+     * @param registry The address of the registry
+     */
+    event RegistrySet(address registry);
+
+    /**
      * @dev ERC-165 check for implementation identifier
      * @dev Supports interfaces IZNSAddressResolver and IERC165
      * @param interfaceId ID to check, XOR of the first 4 bytes of each function signature
@@ -33,4 +39,10 @@ interface IZNSAddressResolver {
     ) external;
 
     function getInterfaceId() external pure returns (bytes4);
+
+    function setRegistry(address _registry) external;
+
+    function setAccessController(address accessController) external;
+
+    function getAccessController() external view returns (address);
 }

--- a/contracts/resolver/ZNSAddressResolver.sol
+++ b/contracts/resolver/ZNSAddressResolver.sol
@@ -11,6 +11,7 @@ contract ZNSAddressResolver is ERC165, IZNSAddressResolver {
      *         for every domain in the system
      */
     IZNSRegistry public registry;
+
     /**
      * @notice Mapping of domain hash to address used to bind domains
      *         to Ethereum wallets or contracts registered in ZNS

--- a/contracts/resolver/ZNSAddressResolver.sol
+++ b/contracts/resolver/ZNSAddressResolver.sol
@@ -81,7 +81,7 @@ contract ZNSAddressResolver is AccessControlled, ERC165, IZNSAddressResolver {
           return type(IZNSAddressResolver).interfaceId;
     }
 
-    function setRegistry(address _registry) public onlyAdmin {
+    function setRegistry(address _registry) public override onlyAdmin {
         require(
             _registry != address(0),
             "ZNSAddressResolver: _registry is 0x0 address"

--- a/contracts/resolver/ZNSAddressResolver.sol
+++ b/contracts/resolver/ZNSAddressResolver.sol
@@ -26,13 +26,10 @@ contract ZNSAddressResolver is ERC165, IZNSAddressResolver {
      * @dev Revert if `msg.sender` is not the owner or an operator allowed by the owner
      * @param domainHash The identifying hash of a domain's name
      */
-    // TODO AC:  Remove this when doing access control (or adapt to work the best way here).
-    //        A function like that can be created in Registry, but think
-    //        deeper if we want this to be for owner in Registry or owner of the Token in DomainToken!
     modifier onlyOwnerOrOperator(bytes32 domainHash) {
         require(
             registry.isOwnerOrOperator(domainHash, msg.sender),
-            "ZNSAddressResolver: Not allowed"
+            "ZNSAddressResolver: Not authorized for this domain"
         );
         _;
     }
@@ -56,8 +53,6 @@ contract ZNSAddressResolver is ERC165, IZNSAddressResolver {
         bytes32 domainHash,
         address newAddress
     ) external override onlyOwnerOrOperator(domainHash) {
-        require(newAddress != address(0), "ZNS: Cant set address to 0");
-
         addressOf[domainHash] = newAddress;
 
         emit AddressSet(domainHash, newAddress);

--- a/contracts/token/IZNSDomainToken.sol
+++ b/contracts/token/IZNSDomainToken.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.18;
+
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
-interface IZNSDomainToken is IERC721{
-    event SetAccessAuthorization(address indexed account);
 
+interface IZNSDomainToken is IERC721 {
     function register(address to, uint256 tokenId) external;
 
     function revoke(uint256 tokenId) external;
 
-    function authorize(address account) external;
+    function setAccessController(address accessController) external;
 }

--- a/contracts/token/IZNSDomainToken.sol
+++ b/contracts/token/IZNSDomainToken.sol
@@ -10,4 +10,6 @@ interface IZNSDomainToken is IERC721 {
     function revoke(uint256 tokenId) external;
 
     function setAccessController(address accessController) external;
+
+    function getAccessController() external view returns (address);
 }

--- a/contracts/token/ZNSDomainToken.sol
+++ b/contracts/token/ZNSDomainToken.sol
@@ -44,7 +44,7 @@ contract ZNSDomainToken is AccessControlled, ERC721, IZNSDomainToken {
 
     function setAccessController(address accessController)
     external
-    override(IZNSDomainToken, AccessControlled)
+    override(AccessControlled, IZNSDomainToken)
     onlyAdmin
     {
         _setAccessController(accessController);

--- a/contracts/token/ZNSDomainToken.sol
+++ b/contracts/token/ZNSDomainToken.sol
@@ -49,4 +49,8 @@ contract ZNSDomainToken is AccessControlled, ERC721, IZNSDomainToken {
     {
         _setAccessController(accessController);
     }
+
+    function getAccessController() external view override(AccessControlled, IZNSDomainToken) returns (address) {
+        return address(accessController);
+    }
 }

--- a/test/ZNSAccessController.test.ts
+++ b/test/ZNSAccessController.test.ts
@@ -3,7 +3,8 @@ import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { ZNSAccessController } from "../typechain";
 import { deployAccessController } from "./helpers";
 import { expect } from "chai";
-import { ADMIN_ROLE, getAccessRevertMsg, GOVERNOR_ROLE, EXECUTOR_ROLE, REGISTRAR_ROLE } from "./helpers/access";
+import { ADMIN_ROLE, GOVERNOR_ROLE, EXECUTOR_ROLE, REGISTRAR_ROLE } from "./helpers/access";
+import { getAccessRevertMsg } from "./helpers/errors";
 
 
 describe("ZNSAccessController", () => {

--- a/test/ZNSAccessController.test.ts
+++ b/test/ZNSAccessController.test.ts
@@ -195,7 +195,7 @@ describe("ZNSAccessController", () => {
 
     it("Should return true for REGISTRAR_ROLE", async () => {
       const [ registrar ] = randomAccs;
-      await znsAccessController.connect(governorAccs[0]).grantRole(REGISTRAR_ROLE, registrar.address);
+      await znsAccessController.connect(adminAccs[0]).grantRole(REGISTRAR_ROLE, registrar.address);
       const isRegistrar = await znsAccessController.isRegistrar(registrar.address);
       expect(isRegistrar).to.be.true;
     });

--- a/test/ZNSAccessController.test.ts
+++ b/test/ZNSAccessController.test.ts
@@ -3,7 +3,7 @@ import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { ZNSAccessController } from "../typechain";
 import { deployAccessController } from "./helpers";
 import { expect } from "chai";
-import { ADMIN_ROLE, getAccessRevertMsg, GOVERNOR_ROLE, OPERATOR_ROLE, REGISTRAR_ROLE } from "./helpers/access";
+import { ADMIN_ROLE, getAccessRevertMsg, GOVERNOR_ROLE, EXECUTOR_ROLE, REGISTRAR_ROLE } from "./helpers/access";
 
 
 describe("ZNSAccessController", () => {
@@ -142,25 +142,25 @@ describe("ZNSAccessController", () => {
       expect(has).to.be.false;
     });
 
-    it("GOVERNOR_ROLE should be able to assign new OPERATOR_ROLE as admin for REGISTRAR_ROLE", async () => {
+    it("GOVERNOR_ROLE should be able to assign new EXECUTOR_ROLE as admin for REGISTRAR_ROLE", async () => {
       const [ governor ] = governorAccs;
-      await znsAccessController.connect(governor).setRoleAdmin(REGISTRAR_ROLE, OPERATOR_ROLE);
+      await znsAccessController.connect(governor).setRoleAdmin(REGISTRAR_ROLE, EXECUTOR_ROLE);
 
       const registrarAdminRole = await znsAccessController.getRoleAdmin(REGISTRAR_ROLE);
-      expect(registrarAdminRole).to.be.equal(OPERATOR_ROLE);
+      expect(registrarAdminRole).to.be.equal(EXECUTOR_ROLE);
     });
 
     // eslint-disable-next-line max-len
-    it("GOVERNOR_ROLE should be able to make himself a new OPERATOR_ROLE's admin and assign this role to anyone", async () => {
+    it("GOVERNOR_ROLE should be able to make himself a new EXECUTOR_ROLE's admin and assign this role to anyone", async () => {
       const [ governor ] = governorAccs;
       const [ { address: newOperator } ] = randomAccs;
 
-      await znsAccessController.connect(governor).setRoleAdmin(OPERATOR_ROLE, GOVERNOR_ROLE);
-      const roleAdminFrom = await znsAccessController.getRoleAdmin(OPERATOR_ROLE);
+      await znsAccessController.connect(governor).setRoleAdmin(EXECUTOR_ROLE, GOVERNOR_ROLE);
+      const roleAdminFrom = await znsAccessController.getRoleAdmin(EXECUTOR_ROLE);
       expect(roleAdminFrom).to.be.equal(GOVERNOR_ROLE);
 
-      await znsAccessController.connect(governor).grantRole(OPERATOR_ROLE, newOperator);
-      const has = await znsAccessController.hasRole(OPERATOR_ROLE, newOperator);
+      await znsAccessController.connect(governor).grantRole(EXECUTOR_ROLE, newOperator);
+      const has = await znsAccessController.hasRole(EXECUTOR_ROLE, newOperator);
       expect(has).to.be.true;
     });
   });

--- a/test/ZNSDomainToken.test.ts
+++ b/test/ZNSDomainToken.test.ts
@@ -6,7 +6,13 @@ import {
 import { expect } from "chai";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { ethers } from "ethers";
-import { ADMIN_ROLE, deployAccessController, deployDomainToken, getAccessRevertMsg, REGISTRAR_ROLE } from "./helpers";
+import {
+  ADMIN_ROLE,
+  deployAccessController,
+  deployDomainToken,
+  getAccessRevertMsg,
+  REGISTRAR_ROLE,
+} from "./helpers";
 
 
 describe("ZNSDomainToken:", () => {

--- a/test/ZNSDomainToken.test.ts
+++ b/test/ZNSDomainToken.test.ts
@@ -1,11 +1,12 @@
 import * as hre from "hardhat";
 import {
+  ZNSAccessController,
   ZNSDomainToken,
 } from "../typechain";
 import { expect } from "chai";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { ethers } from "ethers";
-import { deployDomainToken } from "./helpers";
+import { ADMIN_ROLE, deployAccessController, deployDomainToken, getAccessRevertMsg, REGISTRAR_ROLE } from "./helpers";
 
 
 describe("ZNSDomainToken:", () => {
@@ -13,16 +14,25 @@ describe("ZNSDomainToken:", () => {
   const TokenSymbol = "ZDT";
 
   let deployer : SignerWithAddress;
+  let accessController : ZNSAccessController;
   let caller : SignerWithAddress;
   let domainToken : ZNSDomainToken;
 
   beforeEach(async () => {
     [deployer, caller] = await hre.ethers.getSigners();
-    domainToken = await deployDomainToken(deployer);
+
+    accessController = await deployAccessController({
+      deployer,
+      governorAddresses: [deployer.address],
+      adminAddresses: [deployer.address],
+    });
+
+    domainToken = await deployDomainToken(deployer, accessController.address);
+    await accessController.connect(deployer).grantRole(REGISTRAR_ROLE, deployer.address);
   });
 
   describe("External functions", () => {
-    it("Registers a token", async () => {
+    it("Should register (mint) the token if caller has REGISTRAR_ROLE", async () => {
       const tokenId = ethers.BigNumber.from("1");
       const tx = await domainToken
         .connect(deployer)
@@ -42,7 +52,18 @@ describe("ZNSDomainToken:", () => {
       expect(await domainToken.ownerOf(tokenId)).to.equal(caller.address);
     });
 
-    it("Revokes a token", async () => {
+    it("Should revert when registering (minting) if caller does not have REGISTRAR_ROLE", async () => {
+      const tokenId = ethers.BigNumber.from("1");
+      await expect(
+        domainToken
+          .connect(caller)
+          .register(caller.address, tokenId)
+      ).to.be.revertedWith(
+        getAccessRevertMsg(caller.address, REGISTRAR_ROLE)
+      );
+    });
+
+    it("Should revoke (burn) the token if caller has REGISTRAR_ROLE", async () => {
       const tokenId = ethers.BigNumber.from("1");
       // Mint domain
       await domainToken
@@ -71,33 +92,40 @@ describe("ZNSDomainToken:", () => {
         domainToken.ownerOf(tokenId)
       ).to.be.revertedWith("ERC721: invalid token ID");
     });
-  });
 
-  describe("Require Statement Validation", () => {
-    it("Only authorized can revoke a token", async () => {
+    it("Should revert when revoking (burning) if caller does not have REGISTRAR_ROLE", async () => {
       const tokenId = ethers.BigNumber.from("1");
       // Mint domain
       await domainToken
         .connect(deployer)
         .register(caller.address, tokenId);
-
       // Verify caller owns tokenId
       expect(await domainToken.ownerOf(tokenId)).to.equal(
         caller.address
       );
 
-      // Verify caller owns tokenId
-      expect(await domainToken.ownerOf(tokenId)).to.equal(caller.address);
-
       // Revoke domain
       const tx = domainToken.connect(caller).revoke(tokenId);
       await expect(tx).to.be.revertedWith(
-        "ZNS: Not authorized"
+        getAccessRevertMsg(caller.address, REGISTRAR_ROLE)
       );
 
       // Verify token has not been burned
       expect(await domainToken.ownerOf(tokenId)).to.equal(caller.address);
     });
+  });
+
+  it("Should set access controller if caller has ADMIN_ROLE", async () => {
+    await domainToken.connect(deployer).setAccessController(caller.address);
+    expect(await domainToken.getAccessController()).to.equal(caller.address);
+  });
+
+  it("Should revert when setting access controller if caller does not have ADMIN_ROLE", async () => {
+    await expect(
+      domainToken.connect(caller).setAccessController(caller.address)
+    ).to.be.revertedWith(
+      getAccessRevertMsg(caller.address, ADMIN_ROLE)
+    );
   });
 
   describe("Contract Configuration", () => {

--- a/test/ZNSDomainToken.test.ts
+++ b/test/ZNSDomainToken.test.ts
@@ -10,7 +10,7 @@ import {
   ADMIN_ROLE,
   deployAccessController,
   deployDomainToken,
-  getAccessRevertMsg,
+  getAccessRevertMsg, INVALID_TOKENID_ERC_ERR,
   REGISTRAR_ROLE,
 } from "./helpers";
 
@@ -96,7 +96,7 @@ describe("ZNSDomainToken:", () => {
       // Verify token has been burned
       await expect(
         domainToken.ownerOf(tokenId)
-      ).to.be.revertedWith("ERC721: invalid token ID");
+      ).to.be.revertedWith(INVALID_TOKENID_ERC_ERR);
     });
 
     it("Should revert when revoking (burning) if caller does not have REGISTRAR_ROLE", async () => {
@@ -119,19 +119,19 @@ describe("ZNSDomainToken:", () => {
       // Verify token has not been burned
       expect(await domainToken.ownerOf(tokenId)).to.equal(caller.address);
     });
-  });
 
-  it("Should set access controller if caller has ADMIN_ROLE", async () => {
-    await domainToken.connect(deployer).setAccessController(caller.address);
-    expect(await domainToken.getAccessController()).to.equal(caller.address);
-  });
+    it("Should set access controller if caller has ADMIN_ROLE", async () => {
+      await domainToken.connect(deployer).setAccessController(caller.address);
+      expect(await domainToken.getAccessController()).to.equal(caller.address);
+    });
 
-  it("Should revert when setting access controller if caller does not have ADMIN_ROLE", async () => {
-    await expect(
-      domainToken.connect(caller).setAccessController(caller.address)
-    ).to.be.revertedWith(
-      getAccessRevertMsg(caller.address, ADMIN_ROLE)
-    );
+    it("Should revert when setting access controller if caller does not have ADMIN_ROLE", async () => {
+      await expect(
+        domainToken.connect(caller).setAccessController(caller.address)
+      ).to.be.revertedWith(
+        getAccessRevertMsg(caller.address, ADMIN_ROLE)
+      );
+    });
   });
 
   describe("Contract Configuration", () => {

--- a/test/ZNSEthRegistrar.test.ts
+++ b/test/ZNSEthRegistrar.test.ts
@@ -46,14 +46,6 @@ describe("ZNSEthRegistrar", () => {
       zeroVaultAddress: zeroVault.address,
     });
 
-    // TODO AC: change this when access control implemented
-    // Give the user permission on behalf of the parent domain owner
-    await zns.registry.connect(deployer).setOwnerOperator(user.address, true);
-
-    // TODO AC: change this when access control implemented
-    // Give the registrar permission on behalf of the user
-    await zns.registry.connect(user).setOwnerOperator(zns.registrar.address, true);
-
     // Give funds to user
     await zns.zeroToken.connect(user).approve(zns.treasury.address, ethers.constants.MaxUint256);
     await zns.zeroToken.transfer(user.address, ethers.utils.parseEther("15"));
@@ -107,7 +99,7 @@ describe("ZNSEthRegistrar", () => {
       const balanceBeforeVault = await zns.zeroToken.balanceOf(zeroVault.address);
 
       // Deploy "wilder" with default configuration
-      const tx = await defaultRegistration(user, zns, defaultDomain);
+      const tx = await defaultRegistration(user, zns, defaultDomain, user.address);
       const domainHash = await getDomainHashFromEvent(tx);
       const {
         totalPrice,

--- a/test/ZNSEthRegistrar.test.ts
+++ b/test/ZNSEthRegistrar.test.ts
@@ -59,8 +59,7 @@ describe("ZNSEthRegistrar", () => {
     expect(allowance).to.eq(ethers.constants.MaxUint256);
   });
 
-  // TODO AC: is this a problem it is set up this way?
-  it("Should initialize correctly from an ADMIN account only", async () => {
+  it("Should revert when initialize() without ADMIN_ROLE", async () => {
     const userHasAdmin = await zns.accessController.hasRole(ADMIN_ROLE, user.address);
     expect(userHasAdmin).to.be.false;
 

--- a/test/ZNSEthRegistrar.test.ts
+++ b/test/ZNSEthRegistrar.test.ts
@@ -473,7 +473,9 @@ describe("ZNSEthRegistrar", () => {
           domainHash,
           operator.address
         );
-      await expect(tx2).to.be.revertedWith("ZNSRegistry: Not authorized");
+      await expect(tx2).to.be.revertedWith(
+        "ZNSRegistry: Only Name Owner or Registrar allowed to call"
+      );
 
       const tx3 = zns.registry
         .connect(operator)
@@ -482,7 +484,9 @@ describe("ZNSEthRegistrar", () => {
           user.address,
           operator.address
         );
-      await expect(tx3).to.be.revertedWith("ZNSRegistry: Not authorized");
+      await expect(tx3).to.be.revertedWith(
+        "ZNSRegistry: Not the Name Owner"
+      );
 
       const tx4 = zns.registry
         .connect(operator)
@@ -490,7 +494,9 @@ describe("ZNSEthRegistrar", () => {
           domainHash,
           zeroVault.address
         );
-      await expect(tx4).to.be.revertedWith("ZNSRegistry: Not authorized");
+      await expect(tx4).to.be.revertedWith(
+        "ZNSRegistry: Not authorized"
+      );
     });
   });
 
@@ -521,101 +527,101 @@ describe("ZNSEthRegistrar", () => {
     });
 
     describe("#setZnsRegistry", () => {
-      it("Should set ZNSRegistry and fire ZnsRegistrySet event", async () => {
-        const currentRegistry = await zns.registrar.znsRegistry();
-        const tx = await zns.registrar.connect(deployer).setZnsRegistry(randomAcc.address);
-        const newRegistry = await zns.registrar.znsRegistry();
+      it("Should set ZNSRegistry and fire RegistrySet event", async () => {
+        const currentRegistry = await zns.registrar.registry();
+        const tx = await zns.registrar.connect(deployer).setRegistry(randomAcc.address);
+        const newRegistry = await zns.registrar.registry();
 
-        await expect(tx).to.emit(zns.registrar, "ZnsRegistrySet").withArgs(randomAcc.address);
+        await expect(tx).to.emit(zns.registrar, "RegistrySet").withArgs(randomAcc.address);
 
         expect(newRegistry).to.equal(randomAcc.address);
         expect(currentRegistry).to.not.equal(newRegistry);
       });
 
       it("Should revert if not called by ADMIN", async () => {
-        const tx = zns.registrar.connect(user).setZnsRegistry(randomAcc.address);
+        const tx = zns.registrar.connect(user).setRegistry(randomAcc.address);
         await expect(tx).to.be.revertedWith(
           getAccessRevertMsg(user.address, ADMIN_ROLE)
         );
       });
 
       it("Should revert if ZNSRegistry is address zero", async () => {
-        const tx = zns.registrar.connect(deployer).setZnsRegistry(ethers.constants.AddressZero);
+        const tx = zns.registrar.connect(deployer).setRegistry(ethers.constants.AddressZero);
         await expect(tx).to.be.revertedWith("ZNSEthRegistrar: znsRegistry_ is 0x0 address");
       });
     });
 
-    describe("#setZnsTreasury", () => {
+    describe("#setTreasury", () => {
       it("Should set ZNSTreasury and fire ZnsTreasurySet event", async () => {
-        const currentTreasury = await zns.registrar.znsTreasury();
-        const tx = await zns.registrar.connect(deployer).setZnsTreasury(randomAcc.address);
-        const newTreasury = await zns.registrar.znsTreasury();
+        const currentTreasury = await zns.registrar.treasury();
+        const tx = await zns.registrar.connect(deployer).setTreasury(randomAcc.address);
+        const newTreasury = await zns.registrar.treasury();
 
-        await expect(tx).to.emit(zns.registrar, "ZnsTreasurySet").withArgs(randomAcc.address);
+        await expect(tx).to.emit(zns.registrar, "TreasurySet").withArgs(randomAcc.address);
 
         expect(newTreasury).to.equal(randomAcc.address);
         expect(currentTreasury).to.not.equal(newTreasury);
       });
 
       it("Should revert if not called by ADMIN", async () => {
-        const tx = zns.registrar.connect(user).setZnsTreasury(randomAcc.address);
+        const tx = zns.registrar.connect(user).setTreasury(randomAcc.address);
         await expect(tx).to.be.revertedWith(
           getAccessRevertMsg(user.address, ADMIN_ROLE)
         );
       });
 
       it("Should revert if ZNSTreasury is address zero", async () => {
-        const tx = zns.registrar.connect(deployer).setZnsTreasury(ethers.constants.AddressZero);
+        const tx = zns.registrar.connect(deployer).setTreasury(ethers.constants.AddressZero);
         await expect(tx).to.be.revertedWith("ZNSEthRegistrar: znsTreasury_ is 0x0 address");
       });
     });
 
     describe("#setZnsDomainToken", () => {
       it("Should set ZNSDomainToken and fire ZnsDomainTokenSet event", async () => {
-        const currentToken = await zns.registrar.znsDomainToken();
-        const tx = await zns.registrar.connect(deployer).setZnsDomainToken(randomAcc.address);
-        const newToken = await zns.registrar.znsDomainToken();
+        const currentToken = await zns.registrar.domainToken();
+        const tx = await zns.registrar.connect(deployer).setDomainToken(randomAcc.address);
+        const newToken = await zns.registrar.domainToken();
 
-        await expect(tx).to.emit(zns.registrar, "ZnsDomainTokenSet").withArgs(randomAcc.address);
+        await expect(tx).to.emit(zns.registrar, "DomainTokenSet").withArgs(randomAcc.address);
 
         expect(newToken).to.equal(randomAcc.address);
         expect(currentToken).to.not.equal(newToken);
       });
 
       it("Should revert if not called by ADMIN", async () => {
-        const tx = zns.registrar.connect(user).setZnsDomainToken(randomAcc.address);
+        const tx = zns.registrar.connect(user).setDomainToken(randomAcc.address);
         await expect(tx).to.be.revertedWith(
           getAccessRevertMsg(user.address, ADMIN_ROLE)
         );
       });
 
       it("Should revert if ZNSDomainToken is address zero", async () => {
-        const tx = zns.registrar.connect(deployer).setZnsDomainToken(ethers.constants.AddressZero);
+        const tx = zns.registrar.connect(deployer).setDomainToken(ethers.constants.AddressZero);
         await expect(tx).to.be.revertedWith("ZNSEthRegistrar: znsDomainToken_ is 0x0 address");
       });
     });
 
-    describe("#setZnsAddressResolver", () => {
-      it("Should set ZNSAddressResolver and fire ZnsAddressResolverSet event", async () => {
-        const currentResolver = await zns.registrar.znsAddressResolver();
-        const tx = await zns.registrar.connect(deployer).setZnsAddressResolver(randomAcc.address);
-        const newResolver = await zns.registrar.znsAddressResolver();
+    describe("#setAddressResolver", () => {
+      it("Should set ZNSAddressResolver and fire AddressResolverSet event", async () => {
+        const currentResolver = await zns.registrar.addressResolver();
+        const tx = await zns.registrar.connect(deployer).setAddressResolver(randomAcc.address);
+        const newResolver = await zns.registrar.addressResolver();
 
-        await expect(tx).to.emit(zns.registrar, "ZnsAddressResolverSet").withArgs(randomAcc.address);
+        await expect(tx).to.emit(zns.registrar, "AddressResolverSet").withArgs(randomAcc.address);
 
         expect(newResolver).to.equal(randomAcc.address);
         expect(currentResolver).to.not.equal(newResolver);
       });
 
       it("Should revert if not called by ADMIN", async () => {
-        const tx = zns.registrar.connect(user).setZnsAddressResolver(randomAcc.address);
+        const tx = zns.registrar.connect(user).setAddressResolver(randomAcc.address);
         await expect(tx).to.be.revertedWith(
           getAccessRevertMsg(user.address, ADMIN_ROLE)
         );
       });
 
       it("Should revert if ZNSAddressResolver is address zero", async () => {
-        const tx = zns.registrar.connect(deployer).setZnsAddressResolver(ethers.constants.AddressZero);
+        const tx = zns.registrar.connect(deployer).setAddressResolver(ethers.constants.AddressZero);
         await expect(tx).to.be.revertedWith("ZNSEthRegistrar: znsAddressResolver_ is 0x0 address");
       });
     });

--- a/test/ZNSPriceOracle.test.ts
+++ b/test/ZNSPriceOracle.test.ts
@@ -4,9 +4,10 @@ import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { BigNumber, ethers } from "ethers";
 import { parseEther } from "ethers/lib/utils";
 import { ZNSContracts } from "./helpers/types";
-import { deployZNS, getPrice } from "./helpers";
+import { deployZNS, getPrice, MULTIPLIER_OUT_OF_RANGE_ORA_ERR } from "./helpers";
 import { priceConfigDefault, registrationFeePercDefault } from "./helpers/constants";
-import { ADMIN_ROLE, getAccessRevertMsg } from "./helpers/access";
+import { ADMIN_ROLE } from "./helpers/access";
+import { getAccessRevertMsg } from "./helpers/errors";
 
 require("@nomicfoundation/hardhat-chai-matchers");
 
@@ -345,7 +346,7 @@ describe("ZNSPriceOracle", () => {
       const newMultiplier = BigNumber.from("299");
 
       const tx = zns.priceOracle.connect(deployer).setPriceMultiplier(newMultiplier);
-      await expect(tx).to.be.revertedWith("ZNSPriceOracle: Multiplier out of range");
+      await expect(tx).to.be.revertedWith(MULTIPLIER_OUT_OF_RANGE_ORA_ERR);
     });
 
     it("Fails when setting to a value above the specified range", async () => {
@@ -353,7 +354,7 @@ describe("ZNSPriceOracle", () => {
       const newMultiplier = BigNumber.from("401");
 
       const tx = zns.priceOracle.connect(deployer).setPriceMultiplier(newMultiplier);
-      await expect(tx).to.be.revertedWith("ZNSPriceOracle: Multiplier out of range");
+      await expect(tx).to.be.revertedWith(MULTIPLIER_OUT_OF_RANGE_ORA_ERR);
     });
 
     it("Succeeds when setting a value within the allowed range", async () => {

--- a/test/ZNSPriceOracle.test.ts
+++ b/test/ZNSPriceOracle.test.ts
@@ -345,7 +345,7 @@ describe("ZNSPriceOracle", () => {
       const newMultiplier = BigNumber.from("299");
 
       const tx = zns.priceOracle.connect(deployer).setPriceMultiplier(newMultiplier);
-      await expect(tx).to.be.revertedWith("ZNS: Multiplier out of range");
+      await expect(tx).to.be.revertedWith("ZNSPriceOracle: Multiplier out of range");
     });
 
     it("Fails when setting to a value above the specified range", async () => {
@@ -353,7 +353,7 @@ describe("ZNSPriceOracle", () => {
       const newMultiplier = BigNumber.from("401");
 
       const tx = zns.priceOracle.connect(deployer).setPriceMultiplier(newMultiplier);
-      await expect(tx).to.be.revertedWith("ZNS: Multiplier out of range");
+      await expect(tx).to.be.revertedWith("ZNSPriceOracle: Multiplier out of range");
     });
 
     it("Succeeds when setting a value within the allowed range", async () => {

--- a/test/ZNSRegistry.test.ts
+++ b/test/ZNSRegistry.test.ts
@@ -66,7 +66,7 @@ describe("ZNSRegistry Tests", () => {
     );
   });
 
-  it("Should set access controller correctly with ADMIN_ROLE and revert without", async () => {
+  it("Should set access controller correctly with ADMIN_ROLE", async () => {
     const currentAC = await registry.getAccessController();
 
     await registry.connect(deployer).setAccessController(randomUser.address);
@@ -74,7 +74,9 @@ describe("ZNSRegistry Tests", () => {
 
     expect(currentAC).to.not.equal(newAC);
     expect(newAC).to.equal(randomUser.address);
+  });
 
+  it("Should revert when setting access controller without ADMIN_ROLE", async () => {
     await expect(
       registry.connect(randomUser).setAccessController(deployer.address)
     ).to.be.revertedWith(

--- a/test/ZNSTreasury.test.ts
+++ b/test/ZNSTreasury.test.ts
@@ -5,7 +5,8 @@ import { checkBalance, deployZNS } from "./helpers";
 import { ZNSContracts } from "./helpers/types";
 import * as ethers from "ethers";
 import { hashDomainLabel } from "./helpers/hashing";
-import { ADMIN_ROLE, getAccessRevertMsg, REGISTRAR_ROLE } from "./helpers/access";
+import { ADMIN_ROLE, REGISTRAR_ROLE } from "./helpers/access";
+import { getAccessRevertMsg } from "./helpers/errors";
 
 require("@nomicfoundation/hardhat-chai-matchers");
 

--- a/test/ZNSTreasury.test.ts
+++ b/test/ZNSTreasury.test.ts
@@ -46,7 +46,7 @@ describe("ZNSTreasury", () => {
   });
 
   it("Confirms deployment", async () => {
-    const priceOracle = await zns.treasury.znsPriceOracle();
+    const priceOracle = await zns.treasury.priceOracle();
     const token = await zns.treasury.stakingToken();
     const accessController = await zns.treasury.getAccessController();
 
@@ -166,17 +166,17 @@ describe("ZNSTreasury", () => {
     });
   });
 
-  describe("#setPriceOracle() and ZnsPriceOracleSet event", () => {
+  describe("#setPriceOracle() and PriceOracleSet event", () => {
     it("Should set the correct address of ZNS Price Oracle", async () => {
-      const currentPriceOracle = await zns.treasury.znsPriceOracle();
+      const currentPriceOracle = await zns.treasury.priceOracle();
       expect(currentPriceOracle).to.not.eq(randomAcc.address);
 
       const tx = await zns.treasury.setPriceOracle(randomAcc.address);
 
-      const newPriceOracle = await zns.treasury.znsPriceOracle();
+      const newPriceOracle = await zns.treasury.priceOracle();
       expect(newPriceOracle).to.eq(randomAcc.address);
 
-      await expect(tx).to.emit(zns.treasury, "ZnsPriceOracleSet").withArgs(randomAcc.address);
+      await expect(tx).to.emit(zns.treasury, "PriceOracleSet").withArgs(randomAcc.address);
     });
 
     it("Should revert when called from any address without ADMIN_ROLE", async () => {
@@ -202,7 +202,7 @@ describe("ZNSTreasury", () => {
       const newStakingToken = await zns.treasury.stakingToken();
       expect(newStakingToken).to.eq(randomAcc.address);
 
-      await expect(tx).to.emit(zns.treasury, "ZnsStakingTokenSet").withArgs(randomAcc.address);
+      await expect(tx).to.emit(zns.treasury, "StakingTokenSet").withArgs(randomAcc.address);
     });
 
     it("Should revert when called from any address without ADMIN_ROLE", async () => {

--- a/test/helpers/access.ts
+++ b/test/helpers/access.ts
@@ -17,9 +17,9 @@ export const REGISTRAR_ROLE = ethers.utils.solidityKeccak256(
   ["REGISTRAR_ROLE"]
 );
 
-export const OPERATOR_ROLE = ethers.utils.solidityKeccak256(
+export const EXECUTOR_ROLE = ethers.utils.solidityKeccak256(
   ["string"],
-  ["OPERATOR_ROLE"]
+  ["EXECUTOR_ROLE"]
 );
 
 export const deployAccessController = async ({

--- a/test/helpers/access.ts
+++ b/test/helpers/access.ts
@@ -37,6 +37,3 @@ export const deployAccessController = async ({
   await controller.initialize(governorAddresses, adminAddresses);
   return controller;
 };
-
-export const getAccessRevertMsg = (addr : string, role : string) : string =>
-  `AccessControl: account ${addr.toLowerCase()} is missing role ${role}`;

--- a/test/helpers/deployZNS.ts
+++ b/test/helpers/deployZNS.ts
@@ -195,11 +195,6 @@ export const deployZNS = async ({
     registrar,
   };
 
-  // Final configuration steps
-  // TODO AC: remove all redundant calls here! and delete hashing of the root and the need
-  //  for Registrar to be owner/operator of the root
-  await registry.connect(deployer).setOwnerOperator(registrar.address, true);
-
   // Give 15 ZERO to the deployer and allowance to the treasury
   await zeroTokenMock.connect(deployer).approve(treasury.address, ethers.constants.MaxUint256);
   await zeroTokenMock.transfer(deployer.address, ethers.utils.parseEther("15"));

--- a/test/helpers/deployZNS.ts
+++ b/test/helpers/deployZNS.ts
@@ -37,10 +37,14 @@ export const deployRegistry = async (
 
 export const deployAddressResolver = async (
   deployer : SignerWithAddress,
+  accessControllerAddress : string,
   registryAddress : string
 ) : Promise<ZNSAddressResolver> => {
   const addressResolverFactory = new ZNSAddressResolver__factory(deployer);
-  const addressResolver = await addressResolverFactory.deploy(registryAddress);
+  const addressResolver = await addressResolverFactory.deploy(
+    accessControllerAddress,
+    registryAddress
+  );
 
   return addressResolver;
 };
@@ -150,7 +154,11 @@ export const deployZNS = async ({
 
   const zeroTokenMock = await deployZeroTokenMock(deployer);
 
-  const addressResolver = await deployAddressResolver(deployer, registry.address);
+  const addressResolver = await deployAddressResolver(
+    deployer,
+    accessController.address,
+    registry.address
+  );
 
   const priceOracle = await deployPriceOracle({
     deployer,

--- a/test/helpers/deployZNS.ts
+++ b/test/helpers/deployZNS.ts
@@ -69,10 +69,15 @@ export const deployPriceOracle = async ({
 };
 
 export const deployDomainToken = async (
-  deployer : SignerWithAddress
+  deployer : SignerWithAddress,
+  accessControllerAddress : string
 ) : Promise<ZNSDomainToken> => {
   const domainTokenFactory = new ZNSDomainToken__factory(deployer);
-  return domainTokenFactory.deploy("ZNSDomainToken", "ZDT");
+  return domainTokenFactory.deploy(
+    "ZNSDomainToken",
+    "ZDT",
+    accessControllerAddress
+  );
 };
 
 export const deployZeroTokenMock = async (

--- a/test/helpers/errors.ts
+++ b/test/helpers/errors.ts
@@ -12,3 +12,4 @@ export const NOT_NAME_OWNER_RAR_ERR = "ZNSEthRegistrar: Not the Owner of the Nam
 export const NOT_TOKEN_OWNER_RAR_ERR = "ZNSEthRegistrar: Not the Owner of the Token";
 export const MULTIPLIER_OUT_OF_RANGE_ORA_ERR = "ZNSPriceOracle: Multiplier out of range";
 export const INVALID_TOKENID_ERC_ERR = "ERC721: invalid token ID";
+export const INITIALIZED_ERR = "Initializable: contract is already initialized";

--- a/test/helpers/errors.ts
+++ b/test/helpers/errors.ts
@@ -1,0 +1,14 @@
+export const getAccessRevertMsg = (addr : string, role : string) : string =>
+  `AccessControl: account ${addr.toLowerCase()} is missing role ${role}`;
+
+// revert messages
+// When adding a revert test, check if this message is already present in other tests
+//  if it is, add a new constant here and use it in all tests
+export const ONLY_NAME_OWNER_REG_ERR = "ZNSRegistry: Not the Name Owner";
+export const ONLY_OWNER_REGISTRAR_REG_ERR = "ZNSRegistry: Only Name Owner or Registrar allowed to call";
+export const NOT_AUTHORIZED_REG_ERR = "ZNSRegistry: Not authorized";
+export const OWNER_NOT_ZERO_REG_ERR = "ZNSRegistry: Owner cannot be zero address";
+export const NOT_NAME_OWNER_RAR_ERR = "ZNSEthRegistrar: Not the Owner of the Name";
+export const NOT_TOKEN_OWNER_RAR_ERR = "ZNSEthRegistrar: Not the Owner of the Token";
+export const MULTIPLIER_OUT_OF_RANGE_ORA_ERR = "ZNSPriceOracle: Multiplier out of range";
+export const INVALID_TOKENID_ERC_ERR = "ERC721: invalid token ID";

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -5,3 +5,4 @@ export * from "./hashing";
 export * from "./constants";
 export * from "./balances";
 export * from "./access";
+export * from "./errors";


### PR DESCRIPTION
- Make a safer way for system modules to access role names.
- Convert existing AC protected contracts to use new role validators.
- Convert `ZNSRegistry`, `ZNSDomainToken` and `ZNSAddressResolver` to use the new `ZNSAccessController`