### PR TITLE
fix: [audit] ZNS-1, ZNS-2, vulnerability due to lack of string validation

### DIFF
--- a/contracts/price/IZNSCurvePricer.sol
+++ b/contracts/price/IZNSCurvePricer.sol
@@ -69,7 +69,8 @@ interface IZNSCurvePricer is ICurvePriceConfig, IZNSPricer {
 
     function getPrice(
         bytes32 parentHash,
-        string calldata label
+        string calldata label,
+        bool skipValidityCheck
     ) external view returns (uint256);
 
     function getFeeForPrice(
@@ -79,7 +80,8 @@ interface IZNSCurvePricer is ICurvePriceConfig, IZNSPricer {
 
     function getPriceAndFee(
         bytes32 parentHash,
-        string calldata label
+        string calldata label,
+        bool skipValidityCheck
     ) external view returns (
         uint256 price,
         uint256 stakeFee

--- a/contracts/price/IZNSFixedPricer.sol
+++ b/contracts/price/IZNSFixedPricer.sol
@@ -38,7 +38,11 @@ interface IZNSFixedPricer is IZNSPricer {
 
     function setPrice(bytes32 domainHash, uint256 _price) external;
 
-    function getPrice(bytes32 parentHash, string calldata label) external view returns (uint256);
+    function getPrice(
+        bytes32 parentHash,
+        string calldata label,
+        bool skipValidityCheck
+    ) external view returns (uint256);
 
     function setFeePercentage(
         bytes32 domainHash,
@@ -52,7 +56,8 @@ interface IZNSFixedPricer is IZNSPricer {
 
     function getPriceAndFee(
         bytes32 parentHash,
-        string calldata label
+        string calldata label,
+        bool skipValidityCheck
     ) external view returns (uint256 price, uint256 fee);
 
     function setPriceConfig(

--- a/contracts/price/ZNSCurvePricer.sol
+++ b/contracts/price/ZNSCurvePricer.sol
@@ -61,6 +61,9 @@ contract ZNSCurvePricer is AAccessControlled, ARegistryWired, UUPSUpgradeable, I
         bytes32 parentHash,
         string calldata label
     ) public view override returns (uint256) {
+        // Confirms string values are only [a-z0-9]
+        label.validate();
+
         uint256 length = label.strlen();
         // No pricing is set for 0 length domains
         if (length == 0) return 0;

--- a/contracts/price/ZNSCurvePricer.sol
+++ b/contracts/price/ZNSCurvePricer.sol
@@ -298,8 +298,6 @@ contract ZNSCurvePricer is AAccessControlled, ARegistryWired, UUPSUpgradeable, I
             / config.precisionMultiplier * config.precisionMultiplier;
 
         return price;
-        // To avoid an issue where the config might return less than the min price at a point,
-        // if (price < config.minPrice) return config.minPrice;
     }
 
     /**

--- a/contracts/price/ZNSCurvePricer.sol
+++ b/contracts/price/ZNSCurvePricer.sol
@@ -294,10 +294,8 @@ contract ZNSCurvePricer is AAccessControlled, ARegistryWired, UUPSUpgradeable, I
         if (length <= config.baseLength) return config.maxPrice;
         if (length > config.maxLength) return config.minPrice;
 
-        uint256 price = (config.baseLength * config.maxPrice / length) 
+        return (config.baseLength * config.maxPrice / length)
             / config.precisionMultiplier * config.precisionMultiplier;
-
-        return price;
     }
 
     /**

--- a/contracts/price/ZNSCurvePricer.sol
+++ b/contracts/price/ZNSCurvePricer.sol
@@ -291,9 +291,12 @@ contract ZNSCurvePricer is AAccessControlled, ARegistryWired, UUPSUpgradeable, I
         if (length <= config.baseLength) return config.maxPrice;
         if (length > config.maxLength) return config.minPrice;
 
-        return
-        (config.baseLength * config.maxPrice / length)
-        / config.precisionMultiplier * config.precisionMultiplier;
+        uint256 price = (config.baseLength * config.maxPrice / length) 
+            / config.precisionMultiplier * config.precisionMultiplier;
+
+        return price;
+        // To avoid an issue where the config might return less than the min price at a point,
+        // if (price < config.minPrice) return config.minPrice;
     }
 
     /**

--- a/contracts/price/ZNSCurvePricer.sol
+++ b/contracts/price/ZNSCurvePricer.sol
@@ -54,15 +54,26 @@ contract ZNSCurvePricer is AAccessControlled, ARegistryWired, UUPSUpgradeable, I
 
     /**
      * @notice Get the price of a given domain name
+     * @dev `skipValidityCheck` param is added to provide proper revert when the user is
+     * calling this to find out the price of a domain that is not valid. But in Registrar contracts
+     * we want to do this explicitly and before we get the price to have lower tx cost for reverted tx.
+     * So Registrars will pass this bool as "true" to not repeat the validity check.
+     * Note that if calling this function directly to find out the price, a user should always pass "false"
+     * as `skipValidityCheck` param, otherwise, the price will be returned for an invalid label that is not
+     * possible to register.
      * @param parentHash The hash of the parent domain under which price is determined
      * @param label The label of the subdomain candidate to get the price for before/during registration
+     * @param skipValidityCheck If true, skips the validity check for the label
      */
     function getPrice(
         bytes32 parentHash,
-        string calldata label
+        string calldata label,
+        bool skipValidityCheck
     ) public view override returns (uint256) {
-        // Confirms string values are only [a-z0-9]
-        label.validate();
+        if (!skipValidityCheck) {
+            // Confirms string values are only [a-z0-9-]
+            label.validate();
+        }
 
         uint256 length = label.strlen();
         // No pricing is set for 0 length domains
@@ -94,9 +105,10 @@ contract ZNSCurvePricer is AAccessControlled, ARegistryWired, UUPSUpgradeable, I
     */
     function getPriceAndFee(
         bytes32 parentHash,
-        string calldata label
+        string calldata label,
+        bool skipValidityCheck
     ) external view override returns (uint256 price, uint256 stakeFee) {
-        price = getPrice(parentHash, label);
+        price = getPrice(parentHash, label, skipValidityCheck);
         stakeFee = getFeeForPrice(parentHash, price);
         return (price, stakeFee);
     }

--- a/contracts/price/ZNSFixedPricer.sol
+++ b/contracts/price/ZNSFixedPricer.sol
@@ -55,7 +55,11 @@ contract ZNSFixedPricer is AAccessControlled, ARegistryWired, UUPSUpgradeable, I
      * @param skipValidityCheck If true, skips the validity check for the label
     */
     // solhint-disable-next-line no-unused-vars
-    function getPrice(bytes32 parentHash, string calldata label) public override view returns (uint256) {
+    function getPrice(
+        bytes32 parentHash,
+        string calldata label,
+        bool skipValidityCheck
+    ) public override view returns (uint256) {
         require(
             priceConfigs[parentHash].isSet,
             "ZNSFixedPricer: parent's price config has not been set properly through IZNSPricer.setPriceConfig()"

--- a/contracts/registrar/ZNSRootRegistrar.sol
+++ b/contracts/registrar/ZNSRootRegistrar.sol
@@ -90,18 +90,11 @@ contract ZNSRootRegistrar is
         string calldata tokenURI,
         DistributionConfig calldata distributionConfig
     ) external override returns (bytes32) {
-        // Confirms string values are only [a-z0-9]
+        // Confirms string values are only [a-z0-9-]
         name.validate();
 
-        bytes memory nameBytes = bytes(name);
-
-        require(
-            nameBytes.length != 0,
-            "ZNSRootRegistrar: Domain Name not provided"
-        );
-
         // Create hash for given domain name
-        bytes32 domainHash = keccak256(nameBytes);
+        bytes32 domainHash = keccak256(bytes(name));
 
         require(
             !registry.exists(domainHash),
@@ -109,7 +102,7 @@ contract ZNSRootRegistrar is
         );
 
         // Get price for the domain
-        uint256 domainPrice = rootPricer.getPrice(0x0, name);
+        uint256 domainPrice = rootPricer.getPrice(0x0, name, true);
 
         _coreRegister(
             CoreRegisterArgs(

--- a/contracts/registrar/ZNSRootRegistrar.sol
+++ b/contracts/registrar/ZNSRootRegistrar.sol
@@ -85,7 +85,7 @@ contract ZNSRootRegistrar is
      *      but all the parameters inside are required.
      */
     function registerRootDomain(
-        string memory name,
+        string calldata name,
         address domainAddress,
         string calldata tokenURI,
         DistributionConfig calldata distributionConfig

--- a/contracts/registrar/ZNSRootRegistrar.sol
+++ b/contracts/registrar/ZNSRootRegistrar.sol
@@ -10,6 +10,7 @@ import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils
 import { IZNSSubRegistrar } from "../registrar/IZNSSubRegistrar.sol";
 import { ARegistryWired } from "../registry/ARegistryWired.sol";
 import { IZNSPricer } from "../types/IZNSPricer.sol";
+import { StringUtils } from "../utils/StringUtils.sol";
 
 
 /**
@@ -36,6 +37,8 @@ contract ZNSRootRegistrar is
     IZNSDomainToken public domainToken;
     IZNSAddressResolver public addressResolver;
     IZNSSubRegistrar public subRegistrar;
+
+    using StringUtils for string;
 
     /**
      * @notice Create an instance of the ZNSRootRegistrar.sol
@@ -82,18 +85,39 @@ contract ZNSRootRegistrar is
      *      but all the parameters inside are required.
      */
     function registerRootDomain(
-        string calldata name,
+        string memory name,
         address domainAddress,
         string calldata tokenURI,
         DistributionConfig calldata distributionConfig
     ) external override returns (bytes32) {
+        // Confirms string values are only [a-z0-9]
+        name.validate();
+        bytes memory nameBytes = bytes(name);
+        // uint256 length = nameBytes.length;
+        // // if length < max int, do unchecked math on increment
+        // // only does the above check once instead of every increment
+        // uint256 MAX_INT = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+        // require(length < MAX_INT, "ZNSRootRegistrar: Domain name too long");
+
+        // for(uint256 i; i < length;) {
+        //     require(
+        //         nameBytes[i] > 0x60 && nameBytes[i] < 0x7B,
+        //         "ZNSRootRegistrar: Invalid domain name"
+        //     );
+        //     unchecked {
+        //         ++i;
+        //     }
+        // }
+
+        // perform validation of the name
+        // no capitals or . characters
         require(
-            bytes(name).length != 0,
+            nameBytes.length != 0,
             "ZNSRootRegistrar: Domain Name not provided"
         );
 
         // Create hash for given domain name
-        bytes32 domainHash = keccak256(bytes(name));
+        bytes32 domainHash = keccak256(nameBytes);
 
         require(
             !registry.exists(domainHash),

--- a/contracts/registrar/ZNSRootRegistrar.sol
+++ b/contracts/registrar/ZNSRootRegistrar.sol
@@ -92,25 +92,9 @@ contract ZNSRootRegistrar is
     ) external override returns (bytes32) {
         // Confirms string values are only [a-z0-9]
         name.validate();
+
         bytes memory nameBytes = bytes(name);
-        // uint256 length = nameBytes.length;
-        // // if length < max int, do unchecked math on increment
-        // // only does the above check once instead of every increment
-        // uint256 MAX_INT = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
-        // require(length < MAX_INT, "ZNSRootRegistrar: Domain name too long");
 
-        // for(uint256 i; i < length;) {
-        //     require(
-        //         nameBytes[i] > 0x60 && nameBytes[i] < 0x7B,
-        //         "ZNSRootRegistrar: Invalid domain name"
-        //     );
-        //     unchecked {
-        //         ++i;
-        //     }
-        // }
-
-        // perform validation of the name
-        // no capitals or . characters
         require(
             nameBytes.length != 0,
             "ZNSRootRegistrar: Domain Name not provided"

--- a/contracts/registrar/ZNSSubRegistrar.sol
+++ b/contracts/registrar/ZNSSubRegistrar.sol
@@ -76,7 +76,7 @@ contract ZNSSubRegistrar is AAccessControlled, ARegistryWired, UUPSUpgradeable, 
         string calldata tokenURI,
         DistributionConfig calldata distrConfig
     ) external override returns (bytes32) {
-        // Confirms string values are only [a-z0-9]
+        // Confirms string values are only [a-z0-9-]
         label.validate();
 
         bytes32 domainHash = hashWithParent(parentHash, label);
@@ -117,13 +117,15 @@ contract ZNSSubRegistrar is AAccessControlled, ARegistryWired, UUPSUpgradeable, 
                 (coreRegisterArgs.price, coreRegisterArgs.stakeFee) = IZNSPricer(address(parentConfig.pricerContract))
                     .getPriceAndFee(
                         parentHash,
-                        label
+                        label,
+                        true
                     );
             } else {
                 coreRegisterArgs.price = IZNSPricer(address(parentConfig.pricerContract))
                     .getPrice(
                         parentHash,
-                        label
+                        label,
+                        true
                     );
             }
         }
@@ -192,9 +194,6 @@ contract ZNSSubRegistrar is AAccessControlled, ARegistryWired, UUPSUpgradeable, 
     */
     function setPricerContractForDomain(
         bytes32 domainHash,
-        // TODO audit question: is this a problem that we expect the simplest interface
-        //  but are able set any of the derived ones ??
-        //  Can someone by setting their own contract here introduce a vulnerability ??
         IZNSPricer pricerContract
     ) public override {
         require(

--- a/contracts/registrar/ZNSSubRegistrar.sol
+++ b/contracts/registrar/ZNSSubRegistrar.sol
@@ -6,6 +6,7 @@ import { IZNSRootRegistrar, CoreRegisterArgs } from "./IZNSRootRegistrar.sol";
 import { IZNSSubRegistrar } from "./IZNSSubRegistrar.sol";
 import { AAccessControlled } from "../access/AAccessControlled.sol";
 import { ARegistryWired } from "../registry/ARegistryWired.sol";
+import { StringUtils } from "../utils/StringUtils.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
 
@@ -16,6 +17,7 @@ import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils
  * of any level is in the `ZNSRootRegistrar.coreRegister()`.
 */
 contract ZNSSubRegistrar is AAccessControlled, ARegistryWired, UUPSUpgradeable, IZNSSubRegistrar {
+    using StringUtils for string;
 
     /**
      * @notice State var for the ZNSRootRegistrar contract that finalizes registration of subdomains.
@@ -74,6 +76,9 @@ contract ZNSSubRegistrar is AAccessControlled, ARegistryWired, UUPSUpgradeable, 
         string calldata tokenURI,
         DistributionConfig calldata distrConfig
     ) external override returns (bytes32) {
+        // Confirms string values are only [a-z0-9]
+        label.validate();
+
         bytes32 domainHash = hashWithParent(parentHash, label);
         require(
             !registry.exists(domainHash),

--- a/contracts/types/IZNSPricer.sol
+++ b/contracts/types/IZNSPricer.sol
@@ -10,6 +10,13 @@ interface IZNSPricer {
     /**
      * @dev `parentHash` param is here to allow pricer contracts
      *  to have different price configs for different subdomains
+     * `skipValidityCheck` param is added to provide proper revert when the user is
+     * calling this to find out the price of a domain that is not valid. But in Registrar contracts
+     * we want to do this explicitly and before we get the price to have lower tx cost for reverted tx.
+     * So Registrars will pass this bool as "true" to not repeat the validity check.
+     * Note that if calling this function directly to find out the price, a user should always pass "false"
+     * as `skipValidityCheck` param, otherwise, the price will be returned for an invalid label that is not
+     * possible to register.
      */
     function getPrice(
         bytes32 parentHash,

--- a/contracts/types/IZNSPricer.sol
+++ b/contracts/types/IZNSPricer.sol
@@ -13,7 +13,8 @@ interface IZNSPricer {
      */
     function getPrice(
         bytes32 parentHash,
-        string calldata label
+        string calldata label,
+        bool skipValidityCheck
     ) external view returns (uint256);
 
     /**
@@ -23,7 +24,8 @@ interface IZNSPricer {
      */
     function getPriceAndFee(
         bytes32 parentHash,
-        string calldata label
+        string calldata label,
+        bool skipValidityCheck
     ) external view returns (uint256 price, uint256 fee);
 
     /**

--- a/contracts/upgrade-test-mocks/distribution/ZNSSubRegistrarMock.sol
+++ b/contracts/upgrade-test-mocks/distribution/ZNSSubRegistrarMock.sol
@@ -9,6 +9,8 @@ import { IZNSRootRegistrar, CoreRegisterArgs } from "../../registrar/IZNSRootReg
 import { AAccessControlled } from "../../access/AAccessControlled.sol";
 import { ARegistryWired } from "../../registry/ARegistryWired.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import { StringUtils } from "../../utils/StringUtils.sol";
+
 
 enum AccessType {
     LOCKED,
@@ -72,6 +74,8 @@ contract ZNSSubRegistrarUpgradeMock is
         string memory tokenURI,
         DistributionConfig calldata distrConfig
     ) external returns (bytes32) {
+        label.validate();
+
         DistributionConfig memory parentConfig = distrConfigs[parentHash];
 
         bool isOwnerOrOperator = registry.isOwnerOrOperator(parentHash, msg.sender);
@@ -109,13 +113,15 @@ contract ZNSSubRegistrarUpgradeMock is
                 (coreRegisterArgs.price, coreRegisterArgs.stakeFee) = IZNSPricer(address(parentConfig.pricerContract))
                 .getPriceAndFee(
                     parentHash,
-                    label
+                    label,
+                    true
                 );
             } else {
                 coreRegisterArgs.price = IZNSPricer(address(parentConfig.pricerContract))
                     .getPrice(
                     parentHash,
-                    label
+                    label,
+                    true
                 );
             }
         }

--- a/contracts/upgrade-test-mocks/distribution/ZNSSubRegistrarMock.sol
+++ b/contracts/upgrade-test-mocks/distribution/ZNSSubRegistrarMock.sol
@@ -48,6 +48,8 @@ contract ZNSSubRegistrarUpgradeMock is
     ZNSSubRegistrarMainState,
     UpgradeMock {
 
+    using StringUtils for string;
+
     modifier onlyOwnerOperatorOrRegistrar(bytes32 domainHash) {
         require(
             registry.isOwnerOrOperator(domainHash, msg.sender)

--- a/contracts/utils/StringUtils.sol
+++ b/contracts/utils/StringUtils.sol
@@ -35,7 +35,7 @@ library StringUtils {
     }
 
     /**
-     * @dev Confirm that a given string has only alphanumeric characters [a-z0-9]
+     * @dev Confirm that a given string has only alphanumeric characters [a-z0-9-]
      * @param s The string to validate
      */
     function validate(string memory s) internal pure {
@@ -43,7 +43,7 @@ library StringUtils {
         uint256 length = nameBytes.length;
 
         uint256 MAX_INT = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
-        require(length < MAX_INT, "ZNSRootRegistrar: Domain name too long");
+        require(length < MAX_INT, "StringUtils: Domain name too long");
 
         for (uint256 i; i < length;) {
             bytes1 b = nameBytes[i];

--- a/contracts/utils/StringUtils.sol
+++ b/contracts/utils/StringUtils.sol
@@ -47,8 +47,9 @@ library StringUtils {
 
         for (uint256 i; i < length;) {
             bytes1 b = nameBytes[i];
+            // Valid strings are lower case a-z, 0-9, or a hyphen
             require(
-                (b > 0x60 && b < 0x7B) || (b > 0x2F && b < 0x3A),
+                (b > 0x60 && b < 0x7B) || (b > 0x2F && b < 0x3A) || b == 0x2D,
                 "StringUtils: Invalid domain name"
             );
             unchecked {

--- a/contracts/utils/StringUtils.sol
+++ b/contracts/utils/StringUtils.sol
@@ -49,7 +49,7 @@ library StringUtils {
             bytes1 b = nameBytes[i];
             require(
                 (b > 0x60 && b < 0x7B) || (b > 0x2F && b < 0x3A),
-                "ZNSRootRegistrar: Invalid domain name"
+                "StringUtils: Invalid domain name"
             );
             unchecked {
                 ++i;

--- a/contracts/utils/StringUtils.sol
+++ b/contracts/utils/StringUtils.sol
@@ -33,4 +33,27 @@ library StringUtils {
         }
         return len;
     }
+
+    /**
+     * @dev Confirm that a given string has only alphanumeric characters [a-z0-9]
+     * @param s The string to validate
+     */
+    function validate(string memory s) internal pure {
+        bytes memory nameBytes = bytes(s);
+        uint256 length = nameBytes.length;
+
+        uint256 MAX_INT = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+        require(length < MAX_INT, "ZNSRootRegistrar: Domain name too long");
+
+        for (uint256 i; i < length;) {
+            bytes1 b = nameBytes[i];
+            require(
+                (b > 0x60 && b < 0x7B) || (b > 0x2F && b < 0x3A),
+                "ZNSRootRegistrar: Invalid domain name"
+            );
+            unchecked {
+                ++i;
+            }
+        }
+    }
 }

--- a/contracts/utils/StringUtils.sol
+++ b/contracts/utils/StringUtils.sol
@@ -43,14 +43,17 @@ library StringUtils {
         uint256 length = nameBytes.length;
 
         uint256 MAX_INT = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
-        require(length < MAX_INT, "StringUtils: Domain name too long");
+        require(
+            length > 0 && length < MAX_INT,
+            "StringUtils: Domain label too long or nonexistent"
+        );
 
         for (uint256 i; i < length;) {
             bytes1 b = nameBytes[i];
             // Valid strings are lower case a-z, 0-9, or a hyphen
             require(
                 (b > 0x60 && b < 0x7B) || (b > 0x2F && b < 0x3A) || b == 0x2D,
-                "StringUtils: Invalid domain name"
+                "StringUtils: Invalid domain label"
             );
             unchecked {
                 ++i;

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -71,7 +71,7 @@ const config : HardhatUserConfig = {
     timeout: 5000000,
   },
   gasReporter: {
-    enabled: true
+    enabled: false
   },
   networks: {
     mainnet: {

--- a/test/ZNSCurvePricer.test.ts
+++ b/test/ZNSCurvePricer.test.ts
@@ -257,6 +257,27 @@ describe("ZNSCurvePricer", () => {
   });
 
   describe("#setPriceConfig", () => {
+    // it.only("Specific scenario from the audit", async () => {
+    //   const newConfig = {
+    //     baseLength: BigNumber.from("5"),
+    //     maxLength: BigNumber.from("10"),
+    //     maxPrice: parseEther("10"),
+    //     minPrice: parseEther("5.5"),
+    //     precisionMultiplier: precisionMultiDefault,
+    //     feePercentage: registrationFeePercDefault,
+    //   };
+
+    //   await zns.curvePricer.connect(user).setPriceConfig(domainHash, newConfig);
+
+    //   const nineLength = "abcdefghi";
+    //   const tenLength = "abcdefghij";
+
+    //   const nPrice = await zns.curvePricer.getPrice(domainHash, nineLength);
+    //   const tPrice = await zns.curvePricer.getPrice(domainHash, tenLength);
+
+    //   console.log(nPrice.toString());
+    //   console.log(tPrice.toString());
+    // });
     it("Should set the config for any existing domain hash, including 0x0", async () => {
       const newConfig = {
         baseLength: BigNumber.from("6"),

--- a/test/ZNSFixedPricer.test.ts
+++ b/test/ZNSFixedPricer.test.ts
@@ -4,7 +4,7 @@ import {
   deployZNS,
   getAccessRevertMsg,
   GOVERNOR_ROLE,
-  INITIALIZED_ERR,
+  INITIALIZED_ERR, INVALID_NAME_ERR,
   NOT_AUTHORIZED_REG_WIRED_ERR,
   PaymentType,
   PERCENTAGE_BASIS,
@@ -134,7 +134,7 @@ describe("ZNSFixedPricer", () => {
     await expect(tx).to.emit(zns.fixedPricer, "PriceSet").withArgs(domainHash, newPrice);
 
     expect(
-      await zns.fixedPricer.getPrice(domainHash, "testname")
+      await zns.fixedPricer.getPrice(domainHash, "testname", true)
     ).to.equal(newPrice);
   });
 
@@ -143,8 +143,14 @@ describe("ZNSFixedPricer", () => {
     await zns.fixedPricer.connect(user).setPrice(domainHash, newPrice);
 
     expect(
-      await zns.fixedPricer.getPrice(domainHash, "testname")
+      await zns.fixedPricer.getPrice(domainHash, "testname", false)
     ).to.equal(newPrice);
+  });
+
+  it("#getPrice() should revert for invalid label when not skipping the label validation", async () => {
+    await expect(
+      zns.fixedPricer.getPrice(domainHash, "tEstname", false)
+    ).to.be.revertedWith(INVALID_NAME_ERR);
   });
 
   it("#getPriceAndFee() should return the correct price and fee", async () => {
@@ -156,7 +162,7 @@ describe("ZNSFixedPricer", () => {
     const {
       price,
       fee,
-    } = await zns.fixedPricer.getPriceAndFee(domainHash, "testname");
+    } = await zns.fixedPricer.getPriceAndFee(domainHash, "testname", false);
 
     expect(price).to.equal(newPrice);
     expect(fee).to.equal(newPrice.mul(newFee).div(PERCENTAGE_BASIS));
@@ -351,7 +357,7 @@ describe("ZNSFixedPricer", () => {
         zns.fixedPricer.registry(),
         zns.fixedPricer.getAccessController(),
         zns.fixedPricer.priceConfigs(domainHash),
-        zns.fixedPricer.getPrice(domainHash, "wilder"),
+        zns.fixedPricer.getPrice(domainHash, "wilder", false),
       ];
 
       await validateUpgrade(deployer, zns.fixedPricer, newFixedPricer, factory, contractCalls);

--- a/test/ZNSRootRegistrar.test.ts
+++ b/test/ZNSRootRegistrar.test.ts
@@ -330,6 +330,25 @@ describe("ZNSRootRegistrar", () => {
       ).to.be.revertedWith("ZNSRootRegistrar: Domain Name not provided");
     });
 
+    it.only("Can only register a TLD with characters [a-z]", async () => {
+      const longname = "wilderwilderwilderwilderwilderwilderwilderwilderwilder";
+      const shortname = "dwidler";
+
+      let tx1 = await defaultRootRegistration({
+        user: deployer,
+        zns,
+        domainName: shortname,
+      });
+      console.log(`short: ${tx1.gasUsed.toString()}`);
+
+      let tx2 = await defaultRootRegistration({
+        user: deployer,
+        zns,
+        domainName: longname,
+      });
+      console.log(`long: ${tx2.gasUsed.toString()}`);
+    });
+
     // eslint-disable-next-line max-len
     it("Successfully registers a domain without a resolver or resolver content and fires a #DomainRegistered event", async () => {
       const tokenURI = "https://example.com/817c64af";

--- a/test/ZNSRootRegistrar.test.ts
+++ b/test/ZNSRootRegistrar.test.ts
@@ -5,7 +5,7 @@ import {
   AccessType, defaultTokenURI,
   deployZNS,
   distrConfigEmpty,
-  hashDomainLabel,
+  hashDomainLabel, INVALID_LENGTH_ERR,
   INVALID_TOKENID_ERC_ERR,
   normalizeName,
   NOT_AUTHORIZED_REG_ERR,
@@ -327,7 +327,7 @@ describe("ZNSRootRegistrar", () => {
           zns,
           domainName: emptyName,
         })
-      ).to.be.revertedWith("ZNSRootRegistrar: Domain Name not provided");
+      ).to.be.revertedWith(INVALID_LENGTH_ERR);
     });
 
     it("Can register a TLD with characters [a-z0-9-]", async () => {

--- a/test/ZNSRootRegistrar.test.ts
+++ b/test/ZNSRootRegistrar.test.ts
@@ -829,7 +829,7 @@ describe("ZNSRootRegistrar", () => {
 
       const ogPrice = BigNumber.from(135);
       await zns.fixedPricer.connect(user).setPrice(domainHash, ogPrice);
-      expect(await zns.fixedPricer.getPrice(domainHash, defaultDomain)).to.eq(ogPrice);
+      expect(await zns.fixedPricer.getPrice(domainHash, defaultDomain, false)).to.eq(ogPrice);
 
       const tokenId = await getTokenIdFromReceipt(topLevelTx);
 
@@ -1160,7 +1160,7 @@ describe("ZNSRootRegistrar", () => {
         zns.treasury.stakedForDomain(domainHash),
         zns.domainToken.name(),
         zns.domainToken.symbol(),
-        zns.curvePricer.getPrice(ethers.constants.HashZero, domainName),
+        zns.curvePricer.getPrice(ethers.constants.HashZero, domainName, false),
       ];
 
       await validateUpgrade(deployer, zns.rootRegistrar, registrar, registrarFactory, contractCalls);

--- a/test/ZNSRootRegistrar.test.ts
+++ b/test/ZNSRootRegistrar.test.ts
@@ -330,12 +330,15 @@ describe("ZNSRootRegistrar", () => {
       ).to.be.revertedWith("ZNSRootRegistrar: Domain Name not provided");
     });
 
-    it("Can register a TLD with characters [a-z0-9]", async () => {
+    it.only("Can register a TLD with characters [a-z0-9-]", async () => {
       const letters = "world";
       const lettersHash = hashDomainLabel(letters);
 
       const alphaNumeric = "0x0dwidler0x0";
       const alphaNumericHash = hashDomainLabel(alphaNumeric);
+
+      const withHyphen = "0x0-dwidler-0x0";
+      const withHyphenHash = hashDomainLabel(withHyphen);
 
       const tx1 = zns.rootRegistrar.connect(deployer).registerRootDomain(
         letters,
@@ -365,6 +368,22 @@ describe("ZNSRootRegistrar", () => {
         alphaNumericHash,
         BigNumber.from(alphaNumericHash),
         alphaNumeric,
+        deployer.address,
+        ethers.constants.AddressZero,
+      );
+
+      const tx3 = zns.rootRegistrar.connect(deployer).registerRootDomain(
+        withHyphen,
+        ethers.constants.AddressZero,
+        defaultTokenURI,
+        distrConfigEmpty
+      );
+
+      await expect(tx3).to.emit(zns.rootRegistrar, "DomainRegistered").withArgs(
+        ethers.constants.HashZero,
+        withHyphenHash,
+        BigNumber.from(withHyphenHash),
+        withHyphen,
         deployer.address,
         ethers.constants.AddressZero,
       );

--- a/test/ZNSRootRegistrar.test.ts
+++ b/test/ZNSRootRegistrar.test.ts
@@ -330,7 +330,7 @@ describe("ZNSRootRegistrar", () => {
       ).to.be.revertedWith("ZNSRootRegistrar: Domain Name not provided");
     });
 
-    it.only("Can register a TLD with characters [a-z0-9-]", async () => {
+    it("Can register a TLD with characters [a-z0-9-]", async () => {
       const letters = "world";
       const lettersHash = hashDomainLabel(letters);
 

--- a/test/ZNSSubRegistrar.test.ts
+++ b/test/ZNSSubRegistrar.test.ts
@@ -2079,7 +2079,8 @@ describe("ZNSSubRegistrar", () => {
         stakeFee: feeFromSC,
       } = await zns.curvePricer.getPriceAndFee(
         subdomainParentHash,
-        label
+        label,
+        true
       );
       const protocolFeeFromSC = await zns.curvePricer.getFeeForPrice(
         ethers.constants.HashZero,
@@ -3252,7 +3253,7 @@ describe("ZNSSubRegistrar", () => {
         zns.treasury.stakedForDomain(domainHash),
         zns.domainToken.name(),
         zns.domainToken.symbol(),
-        zns.fixedPricer.getPrice(ethers.constants.HashZero, domainLabel),
+        zns.fixedPricer.getPrice(ethers.constants.HashZero, domainLabel, true),
       ];
 
       await validateUpgrade(deployer, zns.subRegistrar, registrar, registrarFactory, contractCalls);

--- a/test/ZNSTreasury.test.ts
+++ b/test/ZNSTreasury.test.ts
@@ -126,7 +126,8 @@ describe("ZNSTreasury", () => {
 
       const expectedStake = await zns.curvePricer.getPrice(
         ethers.constants.HashZero,
-        domainName
+        domainName,
+        false
       );
       const fee = await zns.curvePricer.getFeeForPrice(ethers.constants.HashZero, expectedStake);
 

--- a/test/gas/gas-costs.json
+++ b/test/gas/gas-costs.json
@@ -1,4 +1,4 @@
 {
-	"Root Domain Price": "425483",
-	"Subdomain Price": "419495"
+	"Root Domain Price": "427687",
+	"Subdomain Price": "423989"
 }

--- a/test/helpers/errors.ts
+++ b/test/helpers/errors.ts
@@ -28,6 +28,9 @@ export const NOT_BOTH_OWNER_RAR_ERR = "ZNSRootRegistrar: Not the owner of both N
 // eslint-disable-next-line max-len
 export const DISTRIBUTION_LOCKED_NOT_EXIST_ERR = "ZNSSubRegistrar: Parent domain's distribution is locked or parent does not exist";
 
+// StringUtils
+export const INVALID_NAME_ERR = "StringUtils: Invalid domain name";
+
 // OpenZeppelin
 export const INVALID_TOKENID_ERC_ERR = "ERC721: invalid token ID";
 export const INITIALIZED_ERR = "Initializable: contract is already initialized";

--- a/test/helpers/errors.ts
+++ b/test/helpers/errors.ts
@@ -29,7 +29,8 @@ export const NOT_BOTH_OWNER_RAR_ERR = "ZNSRootRegistrar: Not the owner of both N
 export const DISTRIBUTION_LOCKED_NOT_EXIST_ERR = "ZNSSubRegistrar: Parent domain's distribution is locked or parent does not exist";
 
 // StringUtils
-export const INVALID_NAME_ERR = "StringUtils: Invalid domain name";
+export const INVALID_NAME_ERR = "StringUtils: Invalid domain label";
+export const INVALID_LENGTH_ERR = "StringUtils: Domain label too long or nonexistent";
 
 // OpenZeppelin
 export const INVALID_TOKENID_ERC_ERR = "ERC721: invalid token ID";

--- a/test/helpers/flows/registration.ts
+++ b/test/helpers/flows/registration.ts
@@ -157,7 +157,7 @@ export const validatePathRegistration = async ({
         ({
           price: expectedPrice,
           fee: stakeFee,
-        } = await zns.fixedPricer.getPriceAndFee(parentHashFound, domainLabel));
+        } = await zns.fixedPricer.getPriceAndFee(parentHashFound, domainLabel, false));
       } else {
         const {
           maxPrice,

--- a/test/helpers/register-setup.ts
+++ b/test/helpers/register-setup.ts
@@ -54,9 +54,9 @@ export const approveForParent = async ({
   let price = BigNumber.from(0);
   let parentFee = BigNumber.from(0);
   if (pricerContract === zns.curvePricer.address) {
-    [price, parentFee] = await zns.curvePricer.getPriceAndFee(parentHash, domainLabel);
+    [price, parentFee] = await zns.curvePricer.getPriceAndFee(parentHash, domainLabel, false);
   } else if (pricerContract === zns.fixedPricer.address) {
-    [price, parentFee] = await zns.fixedPricer.getPriceAndFee(parentHash, domainLabel);
+    [price, parentFee] = await zns.fixedPricer.getPriceAndFee(parentHash, domainLabel, false);
   }
 
   const { token: tokenAddress } = await zns.treasury.paymentConfigs(parentHash);


### PR DESCRIPTION
String validation now exists to only allow domain names to be alphanumeric characters that match `[a-z0-9-]`

By adding this, creating a single domain or subdomain with the name `0://wilder.2ld.3ld.4ld` is not possible because the `.` character does not match this pattern. Any domain name that includes a `.`, a capital letter, or any special character like `!()@#$%^&*?` is not valid. We also no longer allow unicode characters for special things like emojis or letters with accent marks.

Validation function exists in `StringUtils` library

This addresses ZNS-1 in a way as well. Spoofing is still possible because people can mint domains like `w1lder` and `wild3r` which can't really stopped entirely unless we also disallow numbers. This change does, however, address capital letters and other possibly abusable special characters so domains like `Wilder` can't be created