### PR TITLE
fix: [audit] ZNS-4: Address price drop going lower than `minPrice` before `maxLength`

### DIFF
--- a/contracts/price/ZNSCurvePricer.sol
+++ b/contracts/price/ZNSCurvePricer.sol
@@ -307,7 +307,7 @@ contract ZNSCurvePricer is AAccessControlled, ARegistryWired, UUPSUpgradeable, I
      * which can occur if some of the config values are not properly chosen and set.
      */
     function _validateConfig(bytes32 domainHash) internal view {
-        uint256 prevToMinPrice = _getPrice(domainHash, priceConfigs[domainHash].maxLength - 1);
+        uint256 prevToMinPrice = _getPrice(domainHash, priceConfigs[domainHash].maxLength);
         require(
             priceConfigs[domainHash].minPrice <= prevToMinPrice,
             "ZNSCurvePricer: incorrect value set causes the price spike at maxLength."

--- a/contracts/price/ZNSCurvePricer.sol
+++ b/contracts/price/ZNSCurvePricer.sol
@@ -291,9 +291,12 @@ contract ZNSCurvePricer is AAccessControlled, ARegistryWired, UUPSUpgradeable, I
         if (length <= config.baseLength) return config.maxPrice;
         if (length > config.maxLength) return config.minPrice;
 
-        return
-        (config.baseLength * config.maxPrice / length)
+        uint256 price = (config.baseLength * config.maxPrice / length)
         / config.precisionMultiplier * config.precisionMultiplier;
+
+        if(price < config.minPrice) return config.minPrice;
+
+        return price;
     }
 
     /**

--- a/contracts/price/ZNSCurvePricer.sol
+++ b/contracts/price/ZNSCurvePricer.sol
@@ -291,12 +291,8 @@ contract ZNSCurvePricer is AAccessControlled, ARegistryWired, UUPSUpgradeable, I
         if (length <= config.baseLength) return config.maxPrice;
         if (length > config.maxLength) return config.minPrice;
 
-        uint256 price = (config.baseLength * config.maxPrice / length)
+        return (config.baseLength * config.maxPrice / length)
         / config.precisionMultiplier * config.precisionMultiplier;
-
-        if(price < config.minPrice) return config.minPrice;
-
-        return price;
     }
 
     /**

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -71,7 +71,7 @@ const config : HardhatUserConfig = {
     timeout: 5000000,
   },
   gasReporter: {
-    enabled: true
+    enabled: false
   },
   networks: {
     mainnet: {

--- a/test/ZNSCurvePricer.test.ts
+++ b/test/ZNSCurvePricer.test.ts
@@ -100,6 +100,24 @@ describe("ZNSCurvePricer", () => {
   });
 
   describe("#getPrice", async () => {
+    it("Cannot go below the set minPrice", async () => {
+      const newConfig = {
+        baseLength: BigNumber.from("5"),
+        maxLength: BigNumber.from("10"),
+        maxPrice: parseEther("10"),
+        minPrice: parseEther("5.5"),
+        precisionMultiplier: precisionMultiDefault,
+        feePercentage: registrationFeePercDefault,
+      };
+
+      // as a user of "domainHash" that's not 0x0
+      await zns.curvePricer.connect(user).setPriceConfig(domainHash, newConfig);
+
+      let name = "abcdefghij" // length 10
+      const price = await zns.curvePricer.getPrice(domainHash, name);
+      expect(price).to.eq(newConfig.minPrice);
+    });
+
     it("Returns 0 price for a root name with no length", async () => {
       const {
         price,

--- a/test/ZNSCurvePricer.test.ts
+++ b/test/ZNSCurvePricer.test.ts
@@ -301,13 +301,7 @@ describe("ZNSCurvePricer", () => {
         precisionMultiplier: precisionMultiDefault,
         feePercentage: registrationFeePercDefault,
       };
-      // const tx = zns.curvePricer.connect(user).setPriceConfig(domainHash, newConfig);
-      
-      // const a = "abcdefghijabcdefghij" // 20
-      // const b = "abcdefghijabcdefghijk" // 21
-      // const price = await zns.curvePricer.getPrice(domainHash, a);
 
-      // console.log(price.toString());
       await expect(
         zns.curvePricer.connect(user).setPriceConfig(domainHash, newConfig)
       ).to.be.revertedWith(CURVE_PRICE_CONFIG_ERR);

--- a/test/ZNSCurvePricer.test.ts
+++ b/test/ZNSCurvePricer.test.ts
@@ -100,24 +100,6 @@ describe("ZNSCurvePricer", () => {
   });
 
   describe("#getPrice", async () => {
-    it("Cannot go below the set minPrice", async () => {
-      const newConfig = {
-        baseLength: BigNumber.from("5"),
-        maxLength: BigNumber.from("10"),
-        maxPrice: parseEther("10"),
-        minPrice: parseEther("5.5"),
-        precisionMultiplier: precisionMultiDefault,
-        feePercentage: registrationFeePercDefault,
-      };
-
-      // as a user of "domainHash" that's not 0x0
-      await zns.curvePricer.connect(user).setPriceConfig(domainHash, newConfig);
-
-      let name = "abcdefghij" // length 10
-      const price = await zns.curvePricer.getPrice(domainHash, name);
-      expect(price).to.eq(newConfig.minPrice);
-    });
-
     it("Returns 0 price for a root name with no length", async () => {
       const {
         price,
@@ -316,6 +298,22 @@ describe("ZNSCurvePricer", () => {
         maxLength: BigNumber.from("20"),
         maxPrice: parseEther("10"),
         minPrice: parseEther("6"),
+        precisionMultiplier: precisionMultiDefault,
+        feePercentage: registrationFeePercDefault,
+      };
+
+      await expect(
+        zns.curvePricer.connect(user).setPriceConfig(domainHash, newConfig)
+      ).to.be.revertedWith(CURVE_PRICE_CONFIG_ERR);
+    });
+
+    it("Cannot go below the set minPrice", async () => {
+      // Using config numbers from audit
+      const newConfig = {
+        baseLength: BigNumber.from("5"),
+        maxLength: BigNumber.from("10"),
+        maxPrice: parseEther("10"),
+        minPrice: parseEther("5.5"),
         precisionMultiplier: precisionMultiDefault,
         feePercentage: registrationFeePercDefault,
       };

--- a/test/ZNSCurvePricer.test.ts
+++ b/test/ZNSCurvePricer.test.ts
@@ -301,7 +301,13 @@ describe("ZNSCurvePricer", () => {
         precisionMultiplier: precisionMultiDefault,
         feePercentage: registrationFeePercDefault,
       };
+      // const tx = zns.curvePricer.connect(user).setPriceConfig(domainHash, newConfig);
+      
+      // const a = "abcdefghijabcdefghij" // 20
+      // const b = "abcdefghijabcdefghijk" // 21
+      // const price = await zns.curvePricer.getPrice(domainHash, a);
 
+      // console.log(price.toString());
       await expect(
         zns.curvePricer.connect(user).setPriceConfig(domainHash, newConfig)
       ).to.be.revertedWith(CURVE_PRICE_CONFIG_ERR);

--- a/test/ZNSSubRegistrar.test.ts
+++ b/test/ZNSSubRegistrar.test.ts
@@ -1373,9 +1373,9 @@ describe("ZNSSubRegistrar", () => {
       expect(zeroVaultBalanceAfterRevoke.sub(zeroVaultBalanceAfter)).to.eq(0);
     });
 
-    it("CurvePricer - StakePayment - stake fee - 13 decimals", async () => {
+    it.only("CurvePricer - StakePayment - stake fee - 13 decimals", async () => {
       const priceConfig = {
-        maxPrice: parseUnits("25000.93", decimalValues.thirteen),
+        maxPrice: parseUnits("30000.93", decimalValues.thirteen),
         minPrice: parseUnits("2000.11", decimalValues.thirteen),
         maxLength: BigNumber.from(50),
         baseLength: BigNumber.from(4),

--- a/test/ZNSSubRegistrar.test.ts
+++ b/test/ZNSSubRegistrar.test.ts
@@ -1373,7 +1373,7 @@ describe("ZNSSubRegistrar", () => {
       expect(zeroVaultBalanceAfterRevoke.sub(zeroVaultBalanceAfter)).to.eq(0);
     });
 
-    it.only("CurvePricer - StakePayment - stake fee - 13 decimals", async () => {
+    it("CurvePricer - StakePayment - stake fee - 13 decimals", async () => {
       const priceConfig = {
         maxPrice: parseUnits("30000.93", decimalValues.thirteen),
         minPrice: parseUnits("2000.11", decimalValues.thirteen),


### PR DESCRIPTION
Adjusting the validation function to check the correct position and ensure the pricing curve is valid