### PR TITLE
fix: [audit] ZNS-17 - pin pragma numbers

### DIFF
--- a/contracts/access/AAccessControlled.sol
+++ b/contracts/access/AAccessControlled.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 import { IZNSAccessController } from "./IZNSAccessController.sol";
 

--- a/contracts/access/IZNSAccessController.sol
+++ b/contracts/access/IZNSAccessController.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
 

--- a/contracts/access/ZNSAccessController.sol
+++ b/contracts/access/ZNSAccessController.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 import { AccessControl } from "@openzeppelin/contracts/access/AccessControl.sol";
 import { IZNSAccessController } from "./IZNSAccessController.sol";

--- a/contracts/access/ZNSRoles.sol
+++ b/contracts/access/ZNSRoles.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 
 /**

--- a/contracts/oz-proxies/ERC1967ProxyAcc.sol
+++ b/contracts/oz-proxies/ERC1967ProxyAcc.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 // solhint-disable-next-line no-global-import
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";

--- a/contracts/oz-proxies/TransparentUpgradeableProxyAcc.sol
+++ b/contracts/oz-proxies/TransparentUpgradeableProxyAcc.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 // solhint-disable-next-line no-global-import
 import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";

--- a/contracts/price/IZNSCurvePricer.sol
+++ b/contracts/price/IZNSCurvePricer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 import { ICurvePriceConfig } from "../types/ICurvePriceConfig.sol";
 import { IZNSPricer } from "../types/IZNSPricer.sol";

--- a/contracts/price/IZNSFixedPricer.sol
+++ b/contracts/price/IZNSFixedPricer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 import { IZNSPricer } from "../types/IZNSPricer.sol";
 

--- a/contracts/price/ZNSCurvePricer.sol
+++ b/contracts/price/ZNSCurvePricer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import { IZNSCurvePricer } from "./IZNSCurvePricer.sol";

--- a/contracts/price/ZNSFixedPricer.sol
+++ b/contracts/price/ZNSFixedPricer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 import { AAccessControlled } from "../access/AAccessControlled.sol";
 import { ARegistryWired } from "../registry/ARegistryWired.sol";

--- a/contracts/registrar/IZNSRootRegistrar.sol
+++ b/contracts/registrar/IZNSRootRegistrar.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 import { IDistributionConfig } from "../types/IDistributionConfig.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/registrar/IZNSSubRegistrar.sol
+++ b/contracts/registrar/IZNSSubRegistrar.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 import { IDistributionConfig } from "../types/IDistributionConfig.sol";
 import { PaymentConfig } from "../treasury/IZNSTreasury.sol";

--- a/contracts/registrar/ZNSRootRegistrar.sol
+++ b/contracts/registrar/ZNSRootRegistrar.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 import { IZNSRootRegistrar, CoreRegisterArgs } from "./IZNSRootRegistrar.sol";
 import { IZNSTreasury } from "../treasury/IZNSTreasury.sol";

--- a/contracts/registrar/ZNSSubRegistrar.sol
+++ b/contracts/registrar/ZNSSubRegistrar.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 import { IZNSPricer } from "../types/IZNSPricer.sol";
 import { IZNSRootRegistrar, CoreRegisterArgs } from "./IZNSRootRegistrar.sol";

--- a/contracts/registry/ARegistryWired.sol
+++ b/contracts/registry/ARegistryWired.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 import { IZNSRegistry } from "./IZNSRegistry.sol";
 

--- a/contracts/registry/ZNSRegistry.sol
+++ b/contracts/registry/ZNSRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 import { IZNSRegistry } from "./IZNSRegistry.sol";
 import { AAccessControlled } from "../access/AAccessControlled.sol";

--- a/contracts/resolver/IZNSAddressResolver.sol
+++ b/contracts/resolver/IZNSAddressResolver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 
 interface IZNSAddressResolver {

--- a/contracts/resolver/ZNSAddressResolver.sol
+++ b/contracts/resolver/ZNSAddressResolver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 import { ERC165 } from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";

--- a/contracts/token/IZNSDomainToken.sol
+++ b/contracts/token/IZNSDomainToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 import { IERC721Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC721/IERC721Upgradeable.sol";
 import { IERC2981Upgradeable } from "@openzeppelin/contracts-upgradeable/interfaces/IERC2981Upgradeable.sol";

--- a/contracts/token/ZNSDomainToken.sol
+++ b/contracts/token/ZNSDomainToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 import { ERC721Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";

--- a/contracts/token/mocks/CustomDecimalTokenMock.sol
+++ b/contracts/token/mocks/CustomDecimalTokenMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 // solhint-disable
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/contracts/token/mocks/IZeroTokenMock.sol
+++ b/contracts/token/mocks/IZeroTokenMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/token/mocks/ZeroTokenMock.sol
+++ b/contracts/token/mocks/ZeroTokenMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 // solhint-disable
 import { ZeroToken } from "@zero-tech/ztoken/contracts/ZeroToken.sol";

--- a/contracts/treasury/IZNSTreasury.sol
+++ b/contracts/treasury/IZNSTreasury.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/treasury/ZNSTreasury.sol
+++ b/contracts/treasury/ZNSTreasury.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 import { IZNSTreasury } from "./IZNSTreasury.sol";
 import { AAccessControlled } from "../access/AAccessControlled.sol";

--- a/contracts/types/ICurvePriceConfig.sol
+++ b/contracts/types/ICurvePriceConfig.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 
 /**

--- a/contracts/types/IDistributionConfig.sol
+++ b/contracts/types/IDistributionConfig.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 import { IZNSPricer } from "../types/IZNSPricer.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/types/IZNSPricer.sol
+++ b/contracts/types/IZNSPricer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 
 /**

--- a/contracts/upgrade-test-mocks/UpgradeMock.sol
+++ b/contracts/upgrade-test-mocks/UpgradeMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
  /* solhint-disable */
 contract UpgradeMock {

--- a/contracts/upgrade-test-mocks/distribution/ZNSCurvePricerMock.sol
+++ b/contracts/upgrade-test-mocks/distribution/ZNSCurvePricerMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 import { ZNSCurvePricer } from "../../price/ZNSCurvePricer.sol";
 import { UpgradeMock } from "../UpgradeMock.sol";

--- a/contracts/upgrade-test-mocks/distribution/ZNSFixedPricerMock.sol
+++ b/contracts/upgrade-test-mocks/distribution/ZNSFixedPricerMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 import { ZNSFixedPricer } from "../../price/ZNSFixedPricer.sol";
 import { UpgradeMock } from "../UpgradeMock.sol";

--- a/contracts/upgrade-test-mocks/distribution/ZNSRootRegistrarMock.sol
+++ b/contracts/upgrade-test-mocks/distribution/ZNSRootRegistrarMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 import { ZNSRootRegistrar } from "../../registrar/ZNSRootRegistrar.sol";
 import { UpgradeMock } from "../UpgradeMock.sol";

--- a/contracts/upgrade-test-mocks/distribution/ZNSSubRegistrarMock.sol
+++ b/contracts/upgrade-test-mocks/distribution/ZNSSubRegistrarMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 // solhint-disable
 import { ZNSSubRegistrar } from "../../registrar/ZNSSubRegistrar.sol";

--- a/contracts/upgrade-test-mocks/distribution/ZNSTreasuryMock.sol
+++ b/contracts/upgrade-test-mocks/distribution/ZNSTreasuryMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 import { ZNSTreasury } from "../../treasury/ZNSTreasury.sol";
 import { UpgradeMock } from "../UpgradeMock.sol";

--- a/contracts/upgrade-test-mocks/registry/ZNSRegistryMock.sol
+++ b/contracts/upgrade-test-mocks/registry/ZNSRegistryMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 import { ZNSRegistry } from "../../registry/ZNSRegistry.sol";
 import { UpgradeMock } from "../UpgradeMock.sol";

--- a/contracts/upgrade-test-mocks/resolver/ZNSAddressResolverMock.sol
+++ b/contracts/upgrade-test-mocks/resolver/ZNSAddressResolverMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 import { ZNSAddressResolver } from "../../resolver/ZNSAddressResolver.sol";
 import { UpgradeMock } from "../UpgradeMock.sol";

--- a/contracts/upgrade-test-mocks/token/ZNSDomainTokenMock.sol
+++ b/contracts/upgrade-test-mocks/token/ZNSDomainTokenMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 import { ZNSDomainToken } from "../../token/ZNSDomainToken.sol";
 import { UpgradeMock } from "../UpgradeMock.sol";

--- a/contracts/utils/StringUtils.sol
+++ b/contracts/utils/StringUtils.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Source:
 // https://github.com/ensdomains/ens-contracts/blob/master/contracts/ethregistrar/StringUtils.sol
-pragma solidity ^0.8.18;
+pragma solidity 0.8.18;
 
 
 library StringUtils {


### PR DESCRIPTION
Pin the pragma for each contract so the compiler will always be consistent when deployed.