### PR TITLE
[v1.0] Domain data aggregation and validation for use in the migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ coverage.json
 typechain
 typechain-types
 .idea
+dist
 
 # Hardhat files
 cache

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ docker*.tgz
 
 # We don't ever use the generated manifests
 .openzeppelin
+
+output

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -103,7 +103,7 @@ const config : HardhatUserConfig = {
       url: `${process.env.MAINNET_RPC_URL}`,
       accounts: [
         // Read only
-        `${process.env.TESTNET_PRIVATE_KEY_A}`,
+        // `${process.env.TESTNET_PRIVATE_KEY}`, // Commented for CI, uncomment this when using Mainnet
       ],
       gasPrice: 80000000000,
     },

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -100,6 +100,10 @@ const config : HardhatUserConfig = {
   networks: {
     mainnet: {
       url: `${process.env.MAINNET_RPC_URL}`,
+      accounts: [
+        // Read only
+        `${process.env.TESTNET_PRIVATE_KEY_A}`,
+      ],
       gasPrice: 80000000000,
     },
     sepolia: {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "lint"
   ],
   "devDependencies": {
+    "@apollo/client": "^3.5.6",
     "@ensdomains/ensjs": "2.1.0",
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.2",
     "@nomicfoundation/hardhat-ethers": "^3.0.5",
@@ -57,6 +58,7 @@
     "@typechain/ethers-v6": "^0.5.1",
     "@typechain/hardhat": "^9.1.0",
     "@types/chai": "^4.3.11",
+    "@types/graphql": "^14.5.0",
     "@types/mocha": "^9.1.0",
     "@types/node": "^18.15.11",
     "@zero-tech/eslint-config-cpt": "0.2.7",
@@ -66,6 +68,7 @@
     "ethers": "^6.9.0",
     "hardhat": "^2.19.1",
     "hardhat-gas-reporter": "^1.0.9",
+    "react": "^19.1.0",
     "semantic-release": "^21.0.1",
     "solhint": "^4.0.0",
     "solidity-coverage": "^0.8.5",

--- a/src/utils/migration/01_validation.ts
+++ b/src/utils/migration/01_validation.ts
@@ -1,6 +1,6 @@
 import * as hre from "hardhat";
 import { getDomains } from "./subgraph";
-import { Domain, InvalidDomain, User, ValidatedUser } from "./types";
+import { Domain, InvalidDomain } from "./types";
 import { getDBAdapter } from "./database";
 import { getZNS } from "./zns-contract-data";
 import { validateDomain } from "./validate";

--- a/src/utils/migration/01_validation.ts
+++ b/src/utils/migration/01_validation.ts
@@ -1,13 +1,11 @@
 import * as hre from "hardhat";
-import * as fs from "fs";
 import { getUsersAndDomains } from "./subgraph";
 import { Domain } from "./types";
 import { getDBAdapter } from "./database";
-import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 import { getZNS } from "./zns-contract-data";
 import { validateDomain } from "./validate"
-
 import assert from "assert";
+import { ZeroAddress } from "ethers";
 
 
 // For pagination of data in subgraph we use 'first' and 'skip'
@@ -15,7 +13,8 @@ const main = async () => {
   const [ migrationAdmin ] = await hre.ethers.getSigners();
 
   type User = { id: string, domains: Domain[] };
-  type ValidatedUser = { address: string, validDomains: Domain[], invalidDomains: Domain[] };
+  type InvalidDomain = { message: string, domain: Domain };
+  type ValidatedUser = { address: string, validDomains: Domain[], invalidDomains: InvalidDomain[] };
 
   const users = await getUsersAndDomains() as Array<User>;
 
@@ -25,11 +24,18 @@ const main = async () => {
   const validatedUsers : Array<ValidatedUser> = [];
 
   // for each user, iterate list of domains
-  for(let i = 0; i < 5; i++) {
+  for(let i = 0; i < users.slice(0,5).length; i++) {
     const user = users[i];
 
     const validDomains : Array<Domain> = []
-    const invalidDomains : Array<Domain> = [];
+    const invalidDomains : Array<InvalidDomain> = [];
+
+    if (user.id != ZeroAddress) {
+      // As extra validation, be sure the on-chain domain token balance of a user
+      // matches the number of domains given by the subgraph
+      const domainBalance = await zns.domainToken.balanceOf(user.id);
+      assert.equal(domainBalance, user.domains.length);
+    }
 
     for (let j = 0; j < user.domains.length; j++) {
       const domain = user.domains[j];
@@ -37,19 +43,28 @@ const main = async () => {
         await validateDomain(domain, zns, false);
         validDomains.push(domain);
       } catch (e) {
-        invalidDomains.push(domain);
-        // console.log("invalid domain found")
-        // throw (e as Error).message; // no point in try catch if we just throw error?
+        // For debugging we keep invalid domains rather than throw
+        invalidDomains.push({ message: (e as Error).message, domain: domain });
       }
     }
 
-    validatedUsers.push({
-      address: user.id,
-      validDomains,
-      invalidDomains
-    });
+    if (invalidDomains.length === 0 && validDomains.length > 0) {
+      validatedUsers.push({
+        address: user.id,
+        validDomains,
+        invalidDomains
+      });
+    } else {
+        console.log(`Empty or Invalid Domains found for user ${user.id}`);
+        console.log(invalidDomains.length);
+        console.log(validDomains.length);
+    }
+    // } else {
+    //   // Shouldnt reach this
+    //   // should skip if empty
+    // }
 
-    console.log(`Processed: ${i}`);
+    console.log(`Users Processed: ${i + 1}`);
   }
 
   const dbName = "zns-domain-migration";
@@ -67,60 +82,60 @@ const main = async () => {
   process.exit(0);
 };
 
-export const validateDomains = async (
-  admin : SignerWithAddress,
-  users : Array<any> // make user type
-) : Promise<Map<string, Array<Domain>>> => {
-  const start = Date.now();
+// export const validateDomains = async (
+//   admin : SignerWithAddress,
+//   users : Array<any> // make user type
+// ) : Promise<Map<string, Array<Domain>>> => {
+//   const start = Date.now();
 
-  // Get ZNS contracts from the MongoDB instance to validate against
-  const zns = await getZNS(admin);
+//   // Get ZNS contracts from the MongoDB instance to validate against
+//   const zns = await getZNS(admin);
 
-  const invalidDomains : Array<Domain> = [];
+//   const invalidDomains : Array<Domain> = [];
 
-  // array instead?
-  const validatedUsers : Map<string, Array<Domain>> = new Map();
+//   // array instead?
+//   const validatedUsers : Map<string, Array<Domain>> = new Map();
 
-  const validatedUsers2 = [];
-  // TODO remove subset when testedd
-  const subsetUsers = users.slice(0,3);
+//   const validatedUsers2 = [];
+//   // TODO remove subset when testedd
+//   const subsetUsers = users.slice(0,3);
 
-  let counter = 0;
-  for (let user of subsetUsers) {
-    const userDomains = users[counter]
+//   let counter = 0;
+//   for (let user of subsetUsers) {
+//     const userDomains = users[counter]
 
-    console.log(`USERDOMAINS_OBJ: ${userDomains}`);
-    const validDomains : Array<Domain> = []
+//     console.log(`USERDOMAINS_OBJ: ${userDomains}`);
+//     const validDomains : Array<Domain> = []
 
 
-    if (!userDomains) continue;
+//     if (!userDomains) continue;
 
-    for (let domain of userDomains) {
-      try {
-        await validateDomain(domain, zns, false);
-        validDomains.push(domain);
-      } catch (e) {
-        console.log((e as Error).message);
-        invalidDomains.push(domain);
-      }
-    }
+//     for (let domain of userDomains) {
+//       try {
+//         await validateDomain(domain, zns, false);
+//         validDomains.push(domain);
+//       } catch (e) {
+//         console.log((e as Error).message);
+//         invalidDomains.push(domain);
+//       }
+//     }
 
-    validatedUsers.set(user, validDomains);
-    console.log(`Processed: ${++counter}`);
-  }
+//     validatedUsers.set(user, validDomains);
+//     console.log(`Processed: ${++counter}`);
+//   }
 
-  if (invalidDomains.length > 0) {
-    fs.writeFileSync("output/invalid-domains.json", JSON.stringify(invalidDomains, undefined, 2));
-  }
+//   if (invalidDomains.length > 0) {
+//     fs.writeFileSync("output/invalid-domains.json", JSON.stringify(invalidDomains, undefined, 2));
+//   }
 
-  // There should be no invalid domains for full run
-  assert.equal(invalidDomains.length, 0);
+//   // There should be no invalid domains for full run
+//   assert.equal(invalidDomains.length, 0);
 
-  const end = Date.now();
-  console.log(`Validated all domains in ${end - start}ms`);
+//   const end = Date.now();
+//   console.log(`Validated all domains in ${end - start}ms`);
 
-  return validatedUsers;
-}
+//   return validatedUsers;
+// }
 
 main().catch(error => {
   console.error(error);

--- a/src/utils/migration/01_validation.ts
+++ b/src/utils/migration/01_validation.ts
@@ -67,9 +67,8 @@ const main = async () => {
 
   // Domains that have split ownership will be considered invalid domains
   if (invalidDomains.length > 0) {
-    const invalidCollName = process.env.MONGO_DB_INVALID_COLL_NAME || "invalid-domains";
-    await client.dropCollection(invalidCollName);
-    await client.collection(invalidCollName).insertMany(invalidDomains);
+    await client.dropCollection(INVALID_COLL_NAME);
+    await client.collection(INVALID_COLL_NAME).insertMany(invalidDomains);
   }
 };
 

--- a/src/utils/migration/01_validation.ts
+++ b/src/utils/migration/01_validation.ts
@@ -1,20 +1,15 @@
 import * as hre from "hardhat";
 import { getUsersAndDomains } from "./subgraph";
-import { Domain } from "./types";
+import { Domain, InvalidDomain, User, ValidatedUser } from "./types";
 import { getDBAdapter } from "./database";
 import { getZNS } from "./zns-contract-data";
 import { validateDomain } from "./validate"
-import assert from "assert";
 import { ZeroAddress } from "ethers";
 
 
 // For pagination of data in subgraph we use 'first' and 'skip'
 const main = async () => {
   const [ migrationAdmin ] = await hre.ethers.getSigners();
-
-  type User = { id: string, domains: Domain[] };
-  type InvalidDomain = { message: string, domain: Domain };
-  type ValidatedUser = { address: string, validDomains: Domain[], invalidDomains: InvalidDomain[] };
 
   const users = await getUsersAndDomains() as Array<User>;
 
@@ -24,23 +19,13 @@ const main = async () => {
   const validatedUsers : Array<ValidatedUser> = [];
 
   // for each user, iterate list of domains
-  for(let i = 0; i < users.slice(0,5).length; i++) {
-    const user = users[i];
-
+  for(let [index, user] of users.entries()) {
     const validDomains : Array<Domain> = []
     const invalidDomains : Array<InvalidDomain> = [];
 
-    if (user.id != ZeroAddress) {
-      // As extra validation, be sure the on-chain domain token balance of a user
-      // matches the number of domains given by the subgraph
-      const domainBalance = await zns.domainToken.balanceOf(user.id);
-      assert.equal(domainBalance, user.domains.length);
-    }
-
-    for (let j = 0; j < user.domains.length; j++) {
-      const domain = user.domains[j];
+    for (const domain of user.domains) {
       try {
-        await validateDomain(domain, zns, false);
+        await validateDomain(domain, zns);
         validDomains.push(domain);
       } catch (e) {
         // For debugging we keep invalid domains rather than throw
@@ -48,23 +33,16 @@ const main = async () => {
       }
     }
 
-    if (invalidDomains.length === 0 && validDomains.length > 0) {
+    // Skip 0x0 address
+    if (user.id != ZeroAddress) {
       validatedUsers.push({
         address: user.id,
         validDomains,
         invalidDomains
       });
-    } else {
-        console.log(`Empty or Invalid Domains found for user ${user.id}`);
-        console.log(invalidDomains.length);
-        console.log(validDomains.length);
     }
-    // } else {
-    //   // Shouldnt reach this
-    //   // should skip if empty
-    // }
 
-    console.log(`Users Processed: ${i + 1}`);
+    console.log(`Users Processed: ${index + 1}`);
   }
 
   const dbName = "zns-domain-migration";
@@ -81,61 +59,6 @@ const main = async () => {
   // HH not exiting process properly, exit manually
   process.exit(0);
 };
-
-// export const validateDomains = async (
-//   admin : SignerWithAddress,
-//   users : Array<any> // make user type
-// ) : Promise<Map<string, Array<Domain>>> => {
-//   const start = Date.now();
-
-//   // Get ZNS contracts from the MongoDB instance to validate against
-//   const zns = await getZNS(admin);
-
-//   const invalidDomains : Array<Domain> = [];
-
-//   // array instead?
-//   const validatedUsers : Map<string, Array<Domain>> = new Map();
-
-//   const validatedUsers2 = [];
-//   // TODO remove subset when testedd
-//   const subsetUsers = users.slice(0,3);
-
-//   let counter = 0;
-//   for (let user of subsetUsers) {
-//     const userDomains = users[counter]
-
-//     console.log(`USERDOMAINS_OBJ: ${userDomains}`);
-//     const validDomains : Array<Domain> = []
-
-
-//     if (!userDomains) continue;
-
-//     for (let domain of userDomains) {
-//       try {
-//         await validateDomain(domain, zns, false);
-//         validDomains.push(domain);
-//       } catch (e) {
-//         console.log((e as Error).message);
-//         invalidDomains.push(domain);
-//       }
-//     }
-
-//     validatedUsers.set(user, validDomains);
-//     console.log(`Processed: ${++counter}`);
-//   }
-
-//   if (invalidDomains.length > 0) {
-//     fs.writeFileSync("output/invalid-domains.json", JSON.stringify(invalidDomains, undefined, 2));
-//   }
-
-//   // There should be no invalid domains for full run
-//   assert.equal(invalidDomains.length, 0);
-
-//   const end = Date.now();
-//   console.log(`Validated all domains in ${end - start}ms`);
-
-//   return validatedUsers;
-// }
 
 main().catch(error => {
   console.error(error);

--- a/src/utils/migration/01_validation.ts
+++ b/src/utils/migration/01_validation.ts
@@ -1,0 +1,128 @@
+import * as hre from "hardhat";
+import * as fs from "fs";
+import { getUsersAndDomains } from "./subgraph";
+import { Domain } from "./types";
+import { getDBAdapter } from "./database";
+import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+import { getZNS } from "./zns-contract-data";
+import { validateDomain } from "./validate"
+
+import assert from "assert";
+
+
+// For pagination of data in subgraph we use 'first' and 'skip'
+const main = async () => {
+  const [ migrationAdmin ] = await hre.ethers.getSigners();
+
+  type User = { id: string, domains: Domain[] };
+  type ValidatedUser = { address: string, validDomains: Domain[], invalidDomains: Domain[] };
+
+  const users = await getUsersAndDomains() as Array<User>;
+
+  console.log(`Found ${users.length} users`);
+  
+  const zns = await getZNS(migrationAdmin);
+  const validatedUsers : Array<ValidatedUser> = [];
+
+  // for each user, iterate list of domains
+  for(let i = 0; i < 5; i++) {
+    const user = users[i];
+
+    const validDomains : Array<Domain> = []
+    const invalidDomains : Array<Domain> = [];
+
+    for (let j = 0; j < user.domains.length; j++) {
+      const domain = user.domains[j];
+      try {
+        await validateDomain(domain, zns, false);
+        validDomains.push(domain);
+      } catch (e) {
+        invalidDomains.push(domain);
+        // console.log("invalid domain found")
+        // throw (e as Error).message; // no point in try catch if we just throw error?
+      }
+    }
+
+    validatedUsers.push({
+      address: user.id,
+      validDomains,
+      invalidDomains
+    });
+
+    console.log(`Processed: ${i}`);
+  }
+
+  const dbName = "zns-domain-migration";
+  const uri = process.env.MONGO_DB_URI_WRITE;
+
+  if (!uri) throw Error("No connection string provided");
+
+  let client = (await getDBAdapter(uri)).db(dbName);
+
+  // To avoid duplicate data, we clear the DB before any inserts
+  await client.dropCollection("user-domains");
+  await client.collection("user-domains").insertMany(validatedUsers);
+
+  // HH not exiting process properly, exit manually
+  process.exit(0);
+};
+
+export const validateDomains = async (
+  admin : SignerWithAddress,
+  users : Array<any> // make user type
+) : Promise<Map<string, Array<Domain>>> => {
+  const start = Date.now();
+
+  // Get ZNS contracts from the MongoDB instance to validate against
+  const zns = await getZNS(admin);
+
+  const invalidDomains : Array<Domain> = [];
+
+  // array instead?
+  const validatedUsers : Map<string, Array<Domain>> = new Map();
+
+  const validatedUsers2 = [];
+  // TODO remove subset when testedd
+  const subsetUsers = users.slice(0,3);
+
+  let counter = 0;
+  for (let user of subsetUsers) {
+    const userDomains = users[counter]
+
+    console.log(`USERDOMAINS_OBJ: ${userDomains}`);
+    const validDomains : Array<Domain> = []
+
+
+    if (!userDomains) continue;
+
+    for (let domain of userDomains) {
+      try {
+        await validateDomain(domain, zns, false);
+        validDomains.push(domain);
+      } catch (e) {
+        console.log((e as Error).message);
+        invalidDomains.push(domain);
+      }
+    }
+
+    validatedUsers.set(user, validDomains);
+    console.log(`Processed: ${++counter}`);
+  }
+
+  if (invalidDomains.length > 0) {
+    fs.writeFileSync("output/invalid-domains.json", JSON.stringify(invalidDomains, undefined, 2));
+  }
+
+  // There should be no invalid domains for full run
+  assert.equal(invalidDomains.length, 0);
+
+  const end = Date.now();
+  console.log(`Validated all domains in ${end - start}ms`);
+
+  return validatedUsers;
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/utils/migration/02_registration.ts
+++ b/src/utils/migration/02_registration.ts
@@ -1,0 +1,114 @@
+import * as hre from "hardhat";
+import { Domain } from "./types";
+import * as fs from "fs";
+import { deployZNS } from "../../../test/helpers";
+import { postMigrationValidation, registerDomainsBulk } from "./registration";
+import { getZNS } from "./zns-contract-data";
+import { ROOTS_FILENAME, SUBS_FILENAME } from "./constants";
+import { IZNSContracts } from "../../deploy/campaign/types";
+
+// Script #2 to be run AFTER validation of the domains with subgraph
+const main = async () => {
+  const [ migrationAdmin, governor, admin ] = await hre.ethers.getSigners();
+
+  // Read domain data from file output of 01_validate.ts
+  const rootDomains = JSON.parse(fs.readFileSync(ROOTS_FILENAME, {
+    encoding: "utf8"
+  })) as Array<Domain>;
+
+  const subdomains = JSON.parse(fs.readFileSync(SUBS_FILENAME, {
+    encoding: "utf8"
+  })) as Array<Domain>;
+
+  let zns : IZNSContracts;
+
+  if (hre.network.name === "hardhat") {
+    // Reset the network to be sure we aren't forking
+    await hre.network.provider.request({
+      method: "hardhat_reset",
+      params: [],
+    });
+
+    const params = {
+      deployer: migrationAdmin,
+      governorAddresses: [migrationAdmin.address, governor.address],
+      adminAddresses: [migrationAdmin.address, admin.address],
+    };
+
+    // Recreate the domain tree with local ZNS
+    zns = await deployZNS(params);
+  } else if (hre.network.name === "sepolia") {
+    // Get instance of ZNS from DB
+    zns = await getZNS(migrationAdmin);
+  } else {
+    // TODO setup when zchain is deployed
+    throw new Error(`Network ${hre.network.name} not supported`);
+  }
+
+  await zns.meowToken.connect(migrationAdmin).approve(await zns.treasury.getAddress(), hre.ethers.MaxUint256);
+  await zns.meowToken.connect(migrationAdmin).mint(migrationAdmin.address, hre.ethers.parseEther("8000000"));
+
+  console.log(
+    `Balance of admin before: ${await zns.meowToken.balanceOf(migrationAdmin.address)}`
+  );
+
+  // Give approval to the RootRegistrar and SubRegistrar to transfer on behalf of the migration admin
+  await zns.domainToken.connect(migrationAdmin).setApprovalForAll(await zns.rootRegistrar.getAddress(), true);
+  await zns.domainToken.connect(migrationAdmin).setApprovalForAll(await zns.subRegistrar.getAddress(), true);
+
+  const startTime = Date.now();
+
+  // How many domains we will register in a single transaction
+  const sliceSize = 50;
+
+  // TODO because we no longer use the treasury at all we might be able to switch back to
+  // having owners just be the registrant for the domain, not the user then do a transfer
+  // would make it cheaper and faster, but on zchain gas probably won't matter
+  const start = 0;
+
+  console.log(`Registering ${rootDomains.length - start} root domains with slice size ${sliceSize}`);
+  const registeredDomains = await registerDomainsBulk(
+    migrationAdmin,
+    rootDomains,
+    zns,
+    sliceSize,
+    start
+  );
+
+  console.log(`Registering ${subdomains.length} subdomains with slice size ${sliceSize}`);
+  const registeredSubdomains = await registerDomainsBulk(
+    migrationAdmin,
+    subdomains,
+    zns,
+    sliceSize,
+    0
+  );
+
+  // // ms -> s -> min
+  const totalTime = (Date.now() - startTime) / 1000 / 60;
+  console.log(`Registered ${rootDomains.length + subdomains.length} groups of domains in ${totalTime} minutes`);
+  console.log("Done")
+
+  console.log(`txhash: ${registeredDomains[0].txHash}`);
+  console.log(`exists: ${await zns.registry.exists(registeredDomains[0].domainHashes[0])}`);
+
+  console.log(
+    `Balance of admin after: ${await zns.meowToken.balanceOf(migrationAdmin.address)}`
+  );
+
+  // console.log("TEMP just doing postmigration validation for now to test")
+  console.log("Confirming with post-migration validation...");
+  const fullDomains = rootDomains.concat(subdomains);
+  // await postMigrationValidation(
+  //   zns,
+  //   fullDomains
+  // )
+
+  // Manually exit here, HH runner doesn't exit properly
+  process.exit(0);
+};
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/utils/migration/02_registration.ts
+++ b/src/utils/migration/02_registration.ts
@@ -8,6 +8,10 @@ import { ROOTS_FILENAME, SUBS_FILENAME } from "./constants";
 import { IZNSContracts } from "../../deploy/campaign/types";
 import { getDBAdapter } from "./database";
 
+// We will need to adjust this file in the future no matter what after merging happens
+// ignore this file for now
+/* eslint-disable */
+
 // Script #2 to be run AFTER validation of the domains with subgraph
 const main = async () => {
   const [ migrationAdmin, governor, admin ] = await hre.ethers.getSigners();

--- a/src/utils/migration/02_registration.ts
+++ b/src/utils/migration/02_registration.ts
@@ -17,7 +17,7 @@ const main = async () => {
   // read all roots from mongodb
   // while there are unregistered root domains:
   //  register a batch
-  
+
   // read all subs with depth 1 from mongodb
   // while there are unregistered subdomains:
   //  register a batch
@@ -52,7 +52,7 @@ const main = async () => {
   const uri = process.env.MONGO_DB_URI_WRITE;
   if (!uri) throw Error("No connection string given");
 
-  let client = (await getDBAdapter(uri)).db(dbName);
+  const client = (await getDBAdapter(uri)).db(dbName);
 
   const rootCollName = process.env.MONGO_DB_ROOT_COLL_NAME || "root-domains";
 
@@ -65,7 +65,7 @@ const main = async () => {
 
   // How many domains we will register in a single transaction
   const sliceSize = 50;
-  
+
   process.exit(0);
 };
 

--- a/src/utils/migration/02_registration.ts
+++ b/src/utils/migration/02_registration.ts
@@ -11,6 +11,8 @@ import { getDBAdapter } from "./database";
 // We will need to adjust this file in the future no matter what after merging happens
 // ignore this file for now
 /* eslint-disable */
+/* @typescript-eslint-disable */
+
 
 // Script #2 to be run AFTER validation of the domains with subgraph
 const main = async () => {

--- a/src/utils/migration/constants.ts
+++ b/src/utils/migration/constants.ts
@@ -1,0 +1,3 @@
+export const ROOT_COLL_NAME = process.env.MONGO_DB_ROOT_COLL_NAME || "root-domains";
+export const SUB_COLL_NAME = process.env.MONGO_DB_SUB_COLL_NAME || "subdomains";
+export const INVALID_COLL_NAME = process.env.MONGO_DB_INVALID_COLL_NAME || "invalid-domains";

--- a/src/utils/migration/database.ts
+++ b/src/utils/migration/database.ts
@@ -4,7 +4,7 @@ export let dbVersion : string;
 
 export const getDBAdapter = async (
   connectionString : string
-): Promise<MongoClient> => {
+) : Promise<MongoClient> => {
   const mongoClient = new MongoClient(
     connectionString,
     {
@@ -12,12 +12,12 @@ export const getDBAdapter = async (
         version: ServerApiVersion.v1,
         strict: true,
         deprecationErrors: true,
-      }
+      },
     }
   );
 
   return await mongoClient.connect();
-}
+};
 
 export const getZNSFromDB = async () => {
   let version;
@@ -32,7 +32,7 @@ export const getZNSFromDB = async () => {
     throw new Error("Failed to connect: missing MongoDB URI or version");
   }
 
-  let dbAdapter = await getDBAdapter(uri);
+  const dbAdapter = await getDBAdapter(uri);
 
   if(!dbName) {
     throw new Error(`Failed to connect: database "${dbName}" not found`);
@@ -40,7 +40,7 @@ export const getZNSFromDB = async () => {
 
   const db = await dbAdapter.db(dbName);
 
-  let zns = await db.collection("contracts").find(
+  const zns = await db.collection("contracts").find(
     { version }
   ).toArray();
 

--- a/src/utils/migration/database.ts
+++ b/src/utils/migration/database.ts
@@ -16,17 +16,13 @@ export const getDBAdapter = async (
     }
   );
 
-  return await mongoClient.connect();
+  return mongoClient.connect();
 };
 
 export const getZNSFromDB = async () => {
-  let version;
-  let uri;
-  let dbName;
-
-  version = process.env.MONGO_DB_VERSION;
-  uri = process.env.MONGO_DB_URI;
-  dbName = process.env.MONGO_DB_NAME;
+  const version = process.env.MONGO_DB_VERSION;
+  const uri = process.env.MONGO_DB_URI;
+  const dbName = process.env.MONGO_DB_NAME;
 
   if (!uri) {
     throw new Error("Failed to connect: missing MongoDB URI or version");

--- a/src/utils/migration/database.ts
+++ b/src/utils/migration/database.ts
@@ -1,0 +1,48 @@
+import { MongoClient, ServerApiVersion } from "mongodb";
+
+export let dbVersion : string;
+
+export const getDBAdapter = async (
+  connectionString : string
+): Promise<MongoClient> => {
+  const mongoClient = new MongoClient(
+    connectionString,
+    {
+      serverApi: {
+        version: ServerApiVersion.v1,
+        strict: true,
+        deprecationErrors: true,
+      }
+    }
+  );
+
+  return await mongoClient.connect();
+}
+
+export const getZNSFromDB = async () => {
+  let version;
+  let uri;
+  let dbName;
+
+  version = process.env.MONGO_DB_VERSION;
+  uri = process.env.MONGO_DB_URI;
+  dbName = process.env.MONGO_DB_NAME;
+
+  if (!uri) {
+    throw new Error("Failed to connect: missing MongoDB URI or version");
+  }
+
+  let dbAdapter = await getDBAdapter(uri);
+
+  if(!dbName) {
+    throw new Error(`Failed to connect: database "${dbName}" not found`);
+  }
+
+  const db = await dbAdapter.db(dbName);
+
+  let zns = await db.collection("contracts").find(
+    { version }
+  ).toArray();
+
+  return zns;
+};

--- a/src/utils/migration/registration.ts
+++ b/src/utils/migration/registration.ts
@@ -11,6 +11,7 @@ import { ZeroAddress } from "ethers";
 // We will need to adjust this file in the future no matter what after merging happens
 // ignore this file for now
 /* eslint-disable */
+/* @typescript-eslint-disable */
 
 export const registerDomainsBulk = async (
   regAdmin : SignerWithAddress,

--- a/src/utils/migration/registration.ts
+++ b/src/utils/migration/registration.ts
@@ -3,7 +3,6 @@ import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 import { RegisteredDomains, Domain } from "./types";
 import { IZNSContracts } from "../../deploy/campaign/types";
 import { paymentConfigEmpty } from "../../../test/helpers";
-import { IZNSContractsLocal } from "../../../test/helpers/types";
 import { DOMAIN_REGISTERED_TOPIC_SEPOLIA } from "./constants";
 import { expect } from "chai";
 import { validateDomain } from "./validate";

--- a/src/utils/migration/registration.ts
+++ b/src/utils/migration/registration.ts
@@ -1,0 +1,235 @@
+import * as hre from "hardhat";
+import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+import { RegisteredDomains, Domain } from "./types";
+import { IZNSContracts } from "../../deploy/campaign/types";
+import { paymentConfigEmpty } from "../../../test/helpers";
+import { IZNSContractsLocal } from "../../../test/helpers/types";
+import { DOMAIN_REGISTERED_TOPIC_SEPOLIA } from "./constants";
+import { expect } from "chai";
+import { validateDomain } from "./validate";
+import { ZeroAddress } from "ethers";
+
+
+export const registerDomainsBulk = async (
+  regAdmin : SignerWithAddress,
+  domains : Array<Domain>, // imagine this is ALL domains
+  zns : IZNSContracts,
+  sliceSize : number,
+  start : number,
+) => {
+  const registeredDomains = Array<RegisteredDomains>();
+
+  // 'start' is used for retry logic and represents the number of domains
+  // we have already minted
+
+  // The number of iterations to do based on the size of the incoming domain array
+  const numIters = Math.floor((domains.length - start) / sliceSize);
+
+  // Because the terminator represents the *total* number of domains to register,
+  // we add `isStart` back in
+  const terminator = start + (sliceSize * numIters);
+
+  for (let i = start; i < terminator; i += sliceSize) {
+    const domainsForTx = domains.slice(i, i + sliceSize);
+
+    // If the domain hash is already in the registry we have already registered this
+    // batch of domains, so we skip it
+    if (!await zns.registry.exists(domainsForTx[0].id)) {
+      const { domainHashes, txHash, retryData } = await registerBase({
+        regAdmin,
+        zns,
+        domains: domains.slice(i, i + sliceSize)
+      })
+  
+      if (retryData) {
+        throw new Error("Error in registering domains")
+      }
+  
+      registeredDomains.push({ domainHashes, txHash });
+  
+      console.log("Registered domains: ", i + sliceSize);
+    } else {
+      console.log(`Skipping already registered domains: ${i} to ${i + sliceSize}}`);
+    }
+  };
+
+  // In the likely case that the list of domains is not divisble by slice size, we 
+  // want to make sure we do the last set of domains as well
+  const { domainHashes, txHash, retryData } = await registerBase({
+    regAdmin,
+    zns,
+    domains: domains.slice(terminator) // terminator -> end of array
+  })
+
+  if (retryData) {
+    throw new Error("Error in registering domains")
+  }
+
+  console.log("Registered additional domains: ", start + domainHashes.length);
+
+  registeredDomains.push({ domainHashes, txHash });
+
+  return registeredDomains;
+};
+
+export const registerBase = async ({
+  zns,
+  regAdmin,
+  domains
+} : {
+  zns : IZNSContractsLocal | IZNSContracts;
+  regAdmin : SignerWithAddress;
+  domains : Array<Domain>;
+}) => {
+
+  const tokenOwners = domains.map((domain) => { 
+    if (domain.domainToken.owner.id === hre.ethers.ZeroAddress) {
+      // The ERC721 token has been burned, must mint with the record owner instead
+      // to recreate the tree fully
+      return domain.owner.id;
+    } else {
+      return domain.domainToken.owner.id;
+    }
+  });
+
+  const distConfigs = domains.map((domain) => {
+    let config = {
+      pricerContract: "",
+      paymentType: 0n,
+      accessType: 1n // Always use `open` access type for migration
+    };
+
+    // Get pricer contract
+    if (!domain.pricerContract) {
+      config.pricerContract = ZeroAddress;
+    } else {
+      config.pricerContract = domain.pricerContract;
+    }
+
+    // Get payment type
+    if (!domain.paymentType || domain.paymentType === "0") {
+      config.paymentType = 0n;
+    } else {
+      config.paymentType = 1n;
+    }
+
+    return config;
+  });
+
+  // Awaiting this promise within the `map` function below causes type problems
+  // when passing args to the function downstream. This is a workaround.
+  const tokenAddress = await zns.meowToken.getAddress();
+
+  const paymentConfigs = domains.map((domain) => {
+    return {
+      beneficiary: !domain.treasury.beneficiaryAddress 
+        ? ZeroAddress 
+        : domain.treasury.beneficiaryAddress,
+      token: tokenAddress
+    }
+  });
+
+  const recordOwners = domains.map((domain) => { return domain.owner.id });
+  const parentHashes = domains.map((domain) => { return domain.parentHash });
+  const labels = domains.map((domain) => { return domain.label });
+  const domainAddresses = domains.map((domain) => {return domain.address });
+  const tokenURIs = domains.map((domain) => { return domain.tokenURI });
+
+  let tx;
+
+  try {
+    // Because we pre-filter using the query into sets of just root domains and just subdomains
+    // (ordered by depth) we know with certainty that if one parent hash is zero, they all are
+    if (parentHashes[0] === hre.ethers.ZeroHash) {
+
+      const bulkMigrationArgs = {
+        tokenOwners: tokenOwners,
+        recordOwners: recordOwners,
+        names: labels,
+        domainAddresses: domainAddresses,
+        tokenURIs: tokenURIs,
+        distributionConfigs: distConfigs,
+        paymentConfigs: paymentConfigs,
+      }
+
+      // It is by intention that we aren't recreating user configs
+      // We are just focusing on recreating the domain tree
+      tx = await zns.rootRegistrar.connect(regAdmin).registerRootDomainBulk(
+        bulkMigrationArgs,
+        // {
+        //   gasLimit: 5000000 // TODO for debugging
+        // }
+      );
+    } else {
+      const bulkMigrationArgs = {
+        domainToken: await zns.domainToken.getAddress(),
+        tokenOwners: tokenOwners,
+        recordOwners: recordOwners,
+        parentHashes: parentHashes,
+        labels: labels,
+        domainAddresses: domainAddresses,
+        tokenURIs: tokenURIs,
+        distributionConfigs: distConfigs,
+        paymentConfigs: paymentConfigs,
+      };
+
+      tx = await zns.subRegistrar.connect(regAdmin).registerSubdomainBulk(
+        bulkMigrationArgs
+      );
+    }
+  } catch (e) {
+    console.log("Error registering domains: ", e);
+    // Return the domainData if something failed so we can log it
+    // for debugging purposes
+    return {
+      domainHash: undefined,
+      txHash: undefined,
+      retryData: domains
+    }
+  }
+
+  // Providing a number on hardhat will cause it to hang
+  const blocks = hre.network.name === "hardhat" ? 0 : 5;
+  const txReceipt = await tx!.wait(blocks);
+
+  if (!txReceipt) {
+    // Could this ever happen? Need this so downstream return states are never undefined
+    throw new Error("Transaction succeeded without receipt");
+  }
+
+  // Collected the registered domains
+  let domainHashes = Array<string>();
+
+  const drEvents = txReceipt.logs.filter((log) => {
+    if (log.topics[0] === DOMAIN_REGISTERED_TOPIC_SEPOLIA) {
+      return log.topics[1]; // domainHash is always index 1 in this log
+    }
+  })
+  // console.log(`DREVENTS: ${drEvents.length}`);
+
+  drEvents.forEach((log) => {
+    domainHashes.push(log.topics[1]);
+  });
+
+  // console.log(`DOMAINHASHES: ${domainHashes.length}`);
+
+  // console.log(txReceipt.hash);
+
+  return { domainHashes, txHash: txReceipt.hash, retryData: undefined };
+};
+
+export const postMigrationValidation = async (
+  zns : IZNSContractsLocal | IZNSContracts,
+  domains : Array<Domain>,
+) => {
+
+  // TODO figure out error with users who have not called to reclaim there domain
+  // after a transfer
+  for (const domain of domains) {
+    const error = await validateDomain(domain, zns, true);
+
+    if (error) {
+      console.log("Error validating domain: ", error);
+    }
+  }
+}

--- a/src/utils/migration/registration.ts
+++ b/src/utils/migration/registration.ts
@@ -8,6 +8,9 @@ import { expect } from "chai";
 import { validateDomain } from "./validate";
 import { ZeroAddress } from "ethers";
 
+// We will need to adjust this file in the future no matter what after merging happens
+// ignore this file for now
+/* eslint-disable */
 
 export const registerDomainsBulk = async (
   regAdmin : SignerWithAddress,

--- a/src/utils/migration/subgraph/client.ts
+++ b/src/utils/migration/subgraph/client.ts
@@ -1,6 +1,3 @@
-import("@apollo/client");
-
-// CommonJS error
 import {
   ApolloClient, 
   HttpLink, 
@@ -8,7 +5,6 @@ import {
   NormalizedCacheObject
 } from "@apollo/client";
 
-// const apollo = import("@apollo/client");
 
 export const createClient = (subgraphUri ?: string) : ApolloClient<NormalizedCacheObject> => {
   const uri = subgraphUri ? subgraphUri : process.env.SUBGRAPH_URL_DEV;

--- a/src/utils/migration/subgraph/client.ts
+++ b/src/utils/migration/subgraph/client.ts
@@ -1,8 +1,8 @@
 import {
-  ApolloClient, 
-  HttpLink, 
-  InMemoryCache, 
-  NormalizedCacheObject
+  ApolloClient,
+  HttpLink,
+  InMemoryCache,
+  NormalizedCacheObject,
 } from "@apollo/client";
 
 
@@ -12,7 +12,7 @@ export const createClient = (subgraphUri ?: string) : ApolloClient<NormalizedCac
   if (!uri) throw Error("No Subgraph URI provided");
 
   const client = new ApolloClient({
-    link: new HttpLink({ uri: uri, fetch }),
+    link: new HttpLink({ uri, fetch }),
     cache: new InMemoryCache(),
   });
 

--- a/src/utils/migration/subgraph/client.ts
+++ b/src/utils/migration/subgraph/client.ts
@@ -1,0 +1,24 @@
+import("@apollo/client");
+
+// CommonJS error
+import {
+  ApolloClient, 
+  HttpLink, 
+  InMemoryCache, 
+  NormalizedCacheObject
+} from "@apollo/client";
+
+// const apollo = import("@apollo/client");
+
+export const createClient = (subgraphUri ?: string) : ApolloClient<NormalizedCacheObject> => {
+  const uri = subgraphUri ? subgraphUri : process.env.SUBGRAPH_URL_DEV;
+
+  if (!uri) throw Error("No Subgraph URI provided");
+
+  const client = new ApolloClient({
+    link: new HttpLink({ uri: uri, fetch }),
+    cache: new InMemoryCache(),
+  });
+
+  return client;
+};

--- a/src/utils/migration/subgraph/index.ts
+++ b/src/utils/migration/subgraph/index.ts
@@ -3,7 +3,6 @@ import * as q from "./queries";
 
 
 // Grab domain data from the subgraph and validate against what's actually on mainnet
-
 export const getUsersAndDomains = async () => {
   const first = 1000;
   let skip  = 0;

--- a/src/utils/migration/subgraph/index.ts
+++ b/src/utils/migration/subgraph/index.ts
@@ -1,0 +1,54 @@
+import { createClient } from "./client";
+import * as q from "./queries";
+
+
+// Grab domain data from the subgraph and validate against what's actually on mainnet
+
+export const getUsersAndDomains = async () => {
+  const first = 1000;
+  let skip  = 0;
+
+  let client = await createClient();
+
+  // First get all worlds
+  let result = await client.query({
+    query: q.getUsersAndDomains,
+    variables: {
+      first,
+      skip,
+    },
+  });
+
+  if (result.error) throw Error(`Error in graph query: ${result.error}`);
+
+  const users = [];
+
+  // We do this to collect ALL domains in a single array
+  while (result.data.users.length > 0) {
+
+    // For each user, get every domain
+    for (const user of result.data.users) {
+      // user data from subgraph already has user and all domains
+      // so just return this
+      users.push(user);
+    }
+
+    // Get next batch of domains
+    skip += 1000;
+
+    // Refresh client
+    client = await createClient();
+
+    result = await client.query({
+      query: q.getUsersAndDomains,
+      variables: {
+        first,
+        skip,
+      },
+    });
+  }
+
+  return users;
+};
+
+

--- a/src/utils/migration/subgraph/index.ts
+++ b/src/utils/migration/subgraph/index.ts
@@ -1,9 +1,8 @@
 import { createClient } from "./client";
 import * as q from "./queries";
 
-
 // Grab domain data from the subgraph and validate against what's actually on mainnet
-export const getUsersAndDomains = async () => {
+export const getDomains = async (isWorld : boolean) => {
   const first = 1000;
   let skip  = 0;
 
@@ -11,43 +10,44 @@ export const getUsersAndDomains = async () => {
 
   // First get all worlds
   let result = await client.query({
-    query: q.getUsersAndDomains,
+    query: q.getDomains,
     variables: {
       first,
       skip,
+      isWorld
     },
   });
 
   if (result.error) throw Error(`Error in graph query: ${result.error}`);
 
-  const users = [];
+  const domains = [];
 
   // We do this to collect ALL domains in a single array
-  while (result.data.users.length > 0) {
-
+  while (result.data.domains.length > 0) {
     // For each user, get every domain
-    for (const user of result.data.users) {
+    for (const domain of result.data.domains) {
       // user data from subgraph already has user and all domains
       // so just return this
-      users.push(user);
+      domains.push(domain);
     }
 
     // Get next batch of domains
     skip += 1000;
 
-    // Refresh client
+    // Refresh client each iteration
     client = await createClient();
 
     result = await client.query({
-      query: q.getUsersAndDomains,
+      query: q.getDomains,
       variables: {
         first,
         skip,
+        isWorld
       },
     });
   }
 
-  return users;
+  return domains;
 };
 
 

--- a/src/utils/migration/subgraph/index.ts
+++ b/src/utils/migration/subgraph/index.ts
@@ -14,7 +14,7 @@ export const getDomains = async (isWorld : boolean) => {
     variables: {
       first,
       skip,
-      isWorld
+      isWorld,
     },
   });
 
@@ -42,7 +42,7 @@ export const getDomains = async (isWorld : boolean) => {
       variables: {
         first,
         skip,
-        isWorld
+        isWorld,
       },
     });
   }

--- a/src/utils/migration/subgraph/queries.ts
+++ b/src/utils/migration/subgraph/queries.ts
@@ -1,0 +1,57 @@
+import { gql } from "@apollo/client/core";
+
+export const getUsersAndDomains = gql`
+  query Domains($first: Int!, $skip: Int!) {
+    users(first: $first, skip: $skip) {
+      id
+      domains {
+        id
+        minter {
+          id
+        }
+        owner {
+          id
+        }
+        domainToken {
+          owner {
+            id
+          }
+        }
+        isRevoked
+        depth
+        label
+        isWorld
+        address
+        parentHash
+        parent {
+          id
+          isRevoked
+          label
+        }
+        accessType
+        pricerContract
+        paymentToken {
+          id
+          name
+          symbol
+        }
+        paymentType
+        curvePriceConfig {
+          id
+        }
+        fixedPriceConfig {
+          id
+        }
+        subdomainCount
+        address
+        tokenId
+        tokenURI
+        treasury {
+          id
+          beneficiaryAddress
+        }
+        creationBlock
+      }
+    }
+  }
+`;

--- a/src/utils/migration/subgraph/queries.ts
+++ b/src/utils/migration/subgraph/queries.ts
@@ -17,7 +17,6 @@ export const getUsersAndDomains = gql`
             id
           }
         }
-        isRevoked
         depth
         label
         isWorld
@@ -25,16 +24,10 @@ export const getUsersAndDomains = gql`
         parentHash
         parent {
           id
-          isRevoked
           label
         }
         accessType
         pricerContract
-        paymentToken {
-          id
-          name
-          symbol
-        }
         paymentType
         curvePriceConfig {
           id

--- a/src/utils/migration/subgraph/queries.ts
+++ b/src/utils/migration/subgraph/queries.ts
@@ -1,7 +1,7 @@
 import { gql } from "@apollo/client/core";
 
 export const getUsersAndDomains = gql`
-  query Domains($first: Int!, $skip: Int!) {
+  query UserDomains($first: Int!, $skip: Int!) {
     users(first: $first, skip: $skip) {
       id
       domains {
@@ -45,6 +45,61 @@ export const getUsersAndDomains = gql`
         }
         creationBlock
       }
+    }
+  }
+`;
+
+export const getDomains = gql`
+  query Domains($first: Int!, $skip: Int!, $isWorld: Boolean!) {
+    domains(
+      first: $first,
+      skip: $skip
+      where: { isWorld: $isWorld }
+    ) {
+      id
+      minter {
+        id
+      }
+      owner {
+        id
+      }
+      domainToken {
+        owner {
+          id
+        }
+      }
+      depth
+      label
+      isWorld
+      address
+      parentHash
+      amountPaidStake
+      amountPaidDirect
+      parent {
+        id
+        label
+        depth
+        isWorld
+      }
+      accessType
+      pricerContract
+      paymentType
+      curvePriceConfig {
+        id
+      }
+      fixedPriceConfig {
+        id
+      }
+      subdomainCount
+      address
+      tokenId
+      tokenURI
+      treasury {
+        id
+        beneficiaryAddress
+      }
+      creationBlock
+      creationTimestamp
     }
   }
 `;

--- a/src/utils/migration/types.ts
+++ b/src/utils/migration/types.ts
@@ -1,0 +1,96 @@
+import { ContractTransactionReceipt } from "ethers";
+import { IDistributionConfig, IPaymentConfig } from "../../../test/helpers/types";
+
+export interface Domain {
+  id : string;
+  minter : User;
+  owner : User;
+  domainToken : DomainToken;
+  depth : number;
+  label : string;
+  isRevoked : boolean;
+  isReclaimable : boolean;
+  reclaimableAddress : string;
+  isWorld : boolean;
+  address : string;
+  parentHash : string;
+  parent : Domain | null;
+  accessType : string;
+  paymentType : string;
+  pricerContract : string;
+  paymentToken : PaymentToken;
+  curvePriceConfig : CurvePriceConfig;
+  fixedPriceConfig : FixedPriceConfig;
+  subdomainCount : number;
+  tokenId : string;
+  tokenURI : string;
+  treasury : Treasury;
+  creationBlock : number;
+}
+
+interface User {
+  id : string;
+  domains : Array<Domain>;
+}
+
+interface CurvePriceConfig {
+  id : string;
+  baseLength : string;
+  feePercentage : string;
+  maxLength : string;
+  maxPrice : string;
+  minPrice : string;
+  precisionMultiplier : string;
+}
+
+interface FixedPriceConfig {
+  id : string;
+  feePercentage : string;
+  price : string;
+}
+
+interface PaymentToken {
+  id : string;
+  name : string;
+  symbol : string;
+  decimals : string;
+}
+
+interface Treasury {
+  id : string;
+  beneficiaryAddress : string;
+  domain : Domain; // cyclic?
+}
+
+interface DomainToken {
+  baseURI : string;
+  defaultRoyalty : string;
+  owner : User;
+  royalty : string;
+  tokenId : string;
+  tokenName : string;
+  tokenSymbol : string;
+  tokenURI : string;
+}
+
+export interface SubgraphError {
+  label : string;
+  hash : string;
+  parentHash : string;
+  parent : Domain | null;
+  error : string;
+}
+
+export interface DomainData {
+  parentHash : string;
+  label : string;
+  domainAddress : string;
+  tokenUri : string;
+  distrConfig : IDistributionConfig;
+  paymentConfig : IPaymentConfig;
+}
+
+export interface RegisteredDomains {
+  domainHashes : Array<string>,
+  txHash : string
+}

--- a/src/utils/migration/types.ts
+++ b/src/utils/migration/types.ts
@@ -1,4 +1,3 @@
-import { ContractTransactionReceipt } from "ethers";
 import { IDistributionConfig, IPaymentConfig } from "../../../test/helpers/types";
 
 export interface Domain {
@@ -42,13 +41,6 @@ interface FixedPriceConfig {
   price : string;
 }
 
-interface PaymentToken {
-  id : string;
-  name : string;
-  symbol : string;
-  decimals : string;
-}
-
 interface Treasury {
   id : string;
   beneficiaryAddress : string;
@@ -90,4 +82,8 @@ export interface RegisteredDomains {
 
 export interface User { id : string; domains : Array<Domain>; }
 export interface InvalidDomain { message : string; domain : Domain; }
-export interface ValidatedUser { address : string; validDomains : Array<Domain>; invalidDomains : Array<InvalidDomain>; }
+export interface ValidatedUser {
+  address : string;
+  validDomains : Array<Domain>;
+  invalidDomains : Array<InvalidDomain>;
+}

--- a/src/utils/migration/types.ts
+++ b/src/utils/migration/types.ts
@@ -8,7 +8,6 @@ export interface Domain {
   domainToken : DomainToken;
   depth : number;
   label : string;
-  isRevoked : boolean;
   isReclaimable : boolean;
   reclaimableAddress : string;
   isWorld : boolean;
@@ -18,7 +17,6 @@ export interface Domain {
   accessType : string;
   paymentType : string;
   pricerContract : string;
-  paymentToken : PaymentToken;
   curvePriceConfig : CurvePriceConfig;
   fixedPriceConfig : FixedPriceConfig;
   subdomainCount : number;
@@ -26,11 +24,6 @@ export interface Domain {
   tokenURI : string;
   treasury : Treasury;
   creationBlock : number;
-}
-
-interface User {
-  id : string;
-  domains : Array<Domain>;
 }
 
 interface CurvePriceConfig {
@@ -94,3 +87,7 @@ export interface RegisteredDomains {
   domainHashes : Array<string>,
   txHash : string
 }
+
+export type User = { id: string, domains: Domain[] };
+export type InvalidDomain = { message: string, domain: Domain };
+export type ValidatedUser = { address: string, validDomains: Domain[], invalidDomains: InvalidDomain[] };

--- a/src/utils/migration/types.ts
+++ b/src/utils/migration/types.ts
@@ -84,10 +84,10 @@ export interface DomainData {
 }
 
 export interface RegisteredDomains {
-  domainHashes : Array<string>,
-  txHash : string
+  domainHashes : Array<string>;
+  txHash : string;
 }
 
-export type User = { id: string, domains: Domain[] };
-export type InvalidDomain = { message: string, domain: Domain };
-export type ValidatedUser = { address: string, validDomains: Domain[], invalidDomains: InvalidDomain[] };
+export interface User { id : string; domains : Array<Domain>; }
+export interface InvalidDomain { message : string; domain : Domain; }
+export interface ValidatedUser { address : string; validDomains : Array<Domain>; invalidDomains : Array<InvalidDomain>; }

--- a/src/utils/migration/validate.ts
+++ b/src/utils/migration/validate.ts
@@ -67,7 +67,7 @@ export const validateDomain = async (
   );
 
   if (domain.isWorld) {
-    assert.equal(domain.parentHash, ZeroHash), `Domain ${domain.id} 'isWorld' is true, but has parent hash`;
+    assert.equal(domain.parentHash, ZeroHash, `Domain ${domain.id} 'isWorld' is true, but has parent hash`);
     assert.ok(!(!!domain.parent), `Domain ${domain.id} 'isWorld' is true, but 'hasParent' is true`);
     assert.ok(domain.depth === 0, `Domain ${domain.id} 'isWorld' is true, but 'depth' is not 0`);
   } else {

--- a/src/utils/migration/validate.ts
+++ b/src/utils/migration/validate.ts
@@ -13,14 +13,14 @@ export const validateDomain = async (
     zns.registry.getDomainOwner(domain.id),
     zns.domainToken.ownerOf(domain.tokenId),
     zns.addressResolver.resolveDomainAddress(domain.id),
-    zns.subRegistrar.distrConfigs(domain.id)
+    zns.subRegistrar.distrConfigs(domain.id),
   ];
 
   const [
     domainOwner,
     domainTokenOwner,
     domainAddress,
-    distrConfig
+    distrConfig,
   ] = await Promise.all(promises) as unknown as [string, string, string, IDistributionConfig];
 
   assert.equal(

--- a/src/utils/migration/validate.ts
+++ b/src/utils/migration/validate.ts
@@ -1,0 +1,60 @@
+
+import { expect } from "chai";
+import { ZeroAddress, ZeroHash } from "ethers";
+import { Domain } from "./types";
+import { IZNSContracts } from "../../../test/helpers/types";
+import {
+  AccessType,
+  PaymentType,
+} from "../../../test/helpers";
+
+// TODO change to asserts
+
+export const validateDomain = async (
+  domain : Domain, 
+  zns : IZNSContracts,
+  postMigration : boolean = false
+) => {
+  // Because we no longer delete from the store in the subgraph when a domain is revoked
+  // we have to first check `isRevoked` before checking the registry
+  if (!domain.isRevoked) {
+    expect(await zns.registry.exists(domain.id)).to.be.true;
+    expect(
+      (await zns.registry.getDomainOwner(domain.id)).toLowerCase())
+      .to.equal(domain.owner.id.toLowerCase());
+      expect(
+      (await zns.domainToken.ownerOf(domain.tokenId)).toLowerCase())
+      .to.equal(domain.domainToken.owner.id.toLowerCase());
+
+    expect(
+      (await zns.addressResolver.resolveDomainAddress(domain.id)).toLowerCase())
+      .to.equal(domain.address.toLowerCase());
+  }
+
+  const distrConfig = await zns.subRegistrar.distrConfigs(domain.id);
+
+  // Props not yet set in the subgraph return null, but in the contract it will
+  // be 0 value, so we must mediate here
+
+  if (postMigration) {
+    expect(distrConfig.accessType).to.equal(AccessType.OPEN);
+    expect(distrConfig.paymentType).to.equal(PaymentType.DIRECT);
+    expect(distrConfig.pricerContract.toLowerCase()).to.equal(ZeroAddress);  
+  } else {
+    expect(distrConfig.accessType).to.equal(domain.accessType ?? 0n);
+    expect(distrConfig.paymentType).to.equal(domain.paymentType ?? 0n);
+    expect(distrConfig.pricerContract.toLowerCase()).to.equal(domain.pricerContract?.toLowerCase() ?? ZeroAddress);  
+  }
+
+  if (domain.isWorld) {
+    expect(domain.parentHash).to.equal(ZeroHash);
+    expect(!!domain.parent).to.be.false;
+    expect(domain.depth === 0);
+  } else {
+    // Because we no longer delete from the subgraph store on revoke, the domain is always present
+    // even if `isRevoked` is true
+    expect(!!domain.parent).to.be.true;
+    expect(domain.parentHash).to.not.equal(ZeroHash);
+    expect(domain.depth > 0);
+  }
+}

--- a/src/utils/migration/validate.ts
+++ b/src/utils/migration/validate.ts
@@ -10,20 +10,16 @@ export const validateDomain = async (
 ) => {
   // For speed in processing we group promises together
   const promises = [
-    zns.registry.exists(domain.id),
     zns.registry.getDomainOwner(domain.id),
     zns.domainToken.ownerOf(domain.tokenId),
     zns.addressResolver.resolveDomainAddress(domain.id)
   ]
 
   const [
-    exists,
     domainOwner,
     domainTokenOwner,
     domainAddress
-  ] = await Promise.all(promises) as unknown as [boolean, string, string, string];
-
-  assert.ok(!!exists, `Domain ${domain.id} does not exist in the registry`);
+  ] = await Promise.all(promises) as unknown as [string, string, string];
 
   // Domain is in reclaimable state
   assert.equal(

--- a/src/utils/migration/validate.ts
+++ b/src/utils/migration/validate.ts
@@ -1,5 +1,4 @@
 
-import { expect } from "chai";
 import { ZeroAddress, ZeroHash } from "ethers";
 import { Domain } from "./types";
 import { IZNSContracts } from "../../../test/helpers/types";
@@ -7,8 +6,7 @@ import {
   AccessType,
   PaymentType,
 } from "../../../test/helpers";
-
-// TODO change to asserts
+import assert from "assert";
 
 export const validateDomain = async (
   domain : Domain, 
@@ -18,43 +16,63 @@ export const validateDomain = async (
   // Because we no longer delete from the store in the subgraph when a domain is revoked
   // we have to first check `isRevoked` before checking the registry
   if (!domain.isRevoked) {
-    expect(await zns.registry.exists(domain.id)).to.be.true;
-    expect(
-      (await zns.registry.getDomainOwner(domain.id)).toLowerCase())
-      .to.equal(domain.owner.id.toLowerCase());
-      expect(
-      (await zns.domainToken.ownerOf(domain.tokenId)).toLowerCase())
-      .to.equal(domain.domainToken.owner.id.toLowerCase());
 
-    expect(
-      (await zns.addressResolver.resolveDomainAddress(domain.id)).toLowerCase())
-      .to.equal(domain.address.toLowerCase());
+    // For speed in processing we group promises together
+    const promises = [
+      zns.registry.exists(domain.id),
+      zns.registry.getDomainOwner(domain.id),
+      zns.domainToken.ownerOf(domain.tokenId),
+      zns.addressResolver.resolveDomainAddress(domain.id)
+    ]
+
+    const [
+      exists,
+      domainOwner,
+      domainTokenOwner,
+      domainAddress
+    ] = await Promise.all(promises) as unknown as [boolean, string, string, string];
+
+    assert.ok(!!exists);
+
+    assert.equal(
+      domainOwner.toLowerCase(),
+      domain.owner.id.toLowerCase()
+    );
+
+    assert.equal(
+      domainTokenOwner.toLowerCase(),
+      domain.domainToken.owner.id.toLowerCase()
+    );
+
+    assert.equal(
+      domainAddress.toLowerCase(),
+      domain.address.toLowerCase()
+    );
   }
 
   const distrConfig = await zns.subRegistrar.distrConfigs(domain.id);
 
   // Props not yet set in the subgraph return null, but in the contract it will
   // be 0 value, so we must mediate here
-
   if (postMigration) {
-    expect(distrConfig.accessType).to.equal(AccessType.OPEN);
-    expect(distrConfig.paymentType).to.equal(PaymentType.DIRECT);
-    expect(distrConfig.pricerContract.toLowerCase()).to.equal(ZeroAddress);  
+    assert.equal(distrConfig.accessType, AccessType.OPEN);
+    assert.equal(distrConfig.paymentType, PaymentType.DIRECT);
+    assert.equal(distrConfig.pricerContract.toLowerCase(), ZeroAddress);  
   } else {
-    expect(distrConfig.accessType).to.equal(domain.accessType ?? 0n);
-    expect(distrConfig.paymentType).to.equal(domain.paymentType ?? 0n);
-    expect(distrConfig.pricerContract.toLowerCase()).to.equal(domain.pricerContract?.toLowerCase() ?? ZeroAddress);  
+    assert.equal(distrConfig.accessType, domain.accessType ?? 0n);
+    assert.equal(distrConfig.paymentType, domain.paymentType ?? 0n);
+    assert.equal(distrConfig.pricerContract.toLowerCase(), domain.pricerContract?.toLowerCase() ?? ZeroAddress);  
   }
 
   if (domain.isWorld) {
-    expect(domain.parentHash).to.equal(ZeroHash);
-    expect(!!domain.parent).to.be.false;
-    expect(domain.depth === 0);
+    assert.equal(domain.parentHash, ZeroHash);
+    assert.ok(!!domain.parent === false)
+    assert.ok(domain.depth === 0);
   } else {
-    // Because we no longer delete from the subgraph store on revoke, the domain is always present
+    // Because we do not delete from the subgraph store on revoke, the domain is always present
     // even if `isRevoked` is true
-    expect(!!domain.parent).to.be.true;
-    expect(domain.parentHash).to.not.equal(ZeroHash);
-    expect(domain.depth > 0);
+    assert.ok(!!domain.parent);
+    assert.notEqual(domain.parentHash, ZeroHash);
+    assert.ok(domain.depth > 0);
   }
 }

--- a/src/utils/migration/validate.ts
+++ b/src/utils/migration/validate.ts
@@ -2,77 +2,92 @@
 import { ZeroAddress, ZeroHash } from "ethers";
 import { Domain } from "./types";
 import { IZNSContracts } from "../../../test/helpers/types";
-import {
-  AccessType,
-  PaymentType,
-} from "../../../test/helpers";
 import assert from "assert";
 
 export const validateDomain = async (
   domain : Domain, 
   zns : IZNSContracts,
-  postMigration : boolean = false
 ) => {
-  // Because we no longer delete from the store in the subgraph when a domain is revoked
-  // we have to first check `isRevoked` before checking the registry
-  if (!domain.isRevoked) {
+  // For speed in processing we group promises together
+  const promises = [
+    zns.registry.exists(domain.id),
+    zns.registry.getDomainOwner(domain.id),
+    zns.domainToken.ownerOf(domain.tokenId),
+    zns.addressResolver.resolveDomainAddress(domain.id)
+  ]
 
-    // For speed in processing we group promises together
-    const promises = [
-      zns.registry.exists(domain.id),
-      zns.registry.getDomainOwner(domain.id),
-      zns.domainToken.ownerOf(domain.tokenId),
-      zns.addressResolver.resolveDomainAddress(domain.id)
-    ]
+  const [
+    exists,
+    domainOwner,
+    domainTokenOwner,
+    domainAddress
+  ] = await Promise.all(promises) as unknown as [boolean, string, string, string];
 
-    const [
-      exists,
-      domainOwner,
-      domainTokenOwner,
-      domainAddress
-    ] = await Promise.all(promises) as unknown as [boolean, string, string, string];
+  assert.ok(!!exists, `Domain ${domain.id} does not exist in the registry`);
 
-    assert.ok(!!exists);
+  // Domain is in reclaimable state
+  assert.equal(
+    domain.owner.id.toLowerCase(),
+    domain.domainToken.owner.id.toLowerCase(),
+    `Domain ${domain.id} has split ownership.
+    Token owner: ${domain.domainToken.owner.id.toLowerCase()},
+    Domain owner: ${domain.owner.id.toLowerCase()}`
+  );
 
-    assert.equal(
-      domainOwner.toLowerCase(),
-      domain.owner.id.toLowerCase()
-    );
+  assert.equal(
+    domainOwner.toLowerCase(),
+    domain.owner.id.toLowerCase(),
+    `Owner for domain ${domain.id} does not match.
+    Contract: ${domainOwner.toLowerCase()},
+    Subgraph: ${domain.owner.id.toLowerCase()}`
+  );
 
-    assert.equal(
-      domainTokenOwner.toLowerCase(),
-      domain.domainToken.owner.id.toLowerCase()
-    );
+  assert.equal(
+    domainTokenOwner.toLowerCase(),
+    domain.domainToken.owner.id.toLowerCase(),
+    `Owner of domainToken for domain ${domain.id} does not match.
+    Contract: ${domainTokenOwner.toLowerCase()},
+    Subgraph: ${domain.domainToken.owner.id.toLowerCase()}`
+  );
 
-    assert.equal(
-      domainAddress.toLowerCase(),
-      domain.address.toLowerCase()
-    );
-  }
+  assert.equal(
+    domainAddress.toLowerCase(),
+    domain.address.toLowerCase(),
+    `Domain ${domain.id} has differing domain addresses:
+    Contract: ${domainAddress.toLowerCase()}
+    Subgraph: ${domain.address.toLowerCase()}`
+  );
 
   const distrConfig = await zns.subRegistrar.distrConfigs(domain.id);
 
-  // Props not yet set in the subgraph return null, but in the contract it will
-  // be 0 value, so we must mediate here
-  if (postMigration) {
-    assert.equal(distrConfig.accessType, AccessType.OPEN);
-    assert.equal(distrConfig.paymentType, PaymentType.DIRECT);
-    assert.equal(distrConfig.pricerContract.toLowerCase(), ZeroAddress);  
-  } else {
-    assert.equal(distrConfig.accessType, domain.accessType ?? 0n);
-    assert.equal(distrConfig.paymentType, domain.paymentType ?? 0n);
-    assert.equal(distrConfig.pricerContract.toLowerCase(), domain.pricerContract?.toLowerCase() ?? ZeroAddress);  
-  }
+  assert.equal(distrConfig.accessType, domain.accessType ?? 0n,
+    `Domain ${domain.id} has different access types.
+    Contract: ${distrConfig.accessType}
+    Subgraph: ${domain.accessType ?? 0n}
+    `
+  );
+  assert.equal(distrConfig.paymentType, domain.paymentType ?? 0n,
+    `Domain ${domain.id} has different payment types.
+    Contract: ${distrConfig.paymentType}
+    Subgraph: ${domain.paymentType ?? 0n}
+    `
+  );
+  assert.equal(distrConfig.pricerContract.toLowerCase(), domain.pricerContract?.toLowerCase() ?? ZeroAddress,
+    `Domain ${domain.id} has different pricer contracts.
+    Contract: ${distrConfig.pricerContract.toLowerCase()}
+    Subgraph: ${domain.pricerContract?.toLowerCase() ?? ZeroAddress}
+    `
+  );  
 
   if (domain.isWorld) {
-    assert.equal(domain.parentHash, ZeroHash);
-    assert.ok(!!domain.parent === false)
-    assert.ok(domain.depth === 0);
+    assert.equal(domain.parentHash, ZeroHash), `Domain ${domain.id} 'isWorld' is true, but has parent hash`;
+    assert.ok(!!domain.parent === false, `Domain ${domain.id} 'isWorld' is true, but 'hasParent' is true`)
+    assert.ok(domain.depth === 0, `Domain ${domain.id} 'isWorld' is true, but 'depth' is not 0`);
   } else {
     // Because we do not delete from the subgraph store on revoke, the domain is always present
     // even if `isRevoked` is true
-    assert.ok(!!domain.parent);
-    assert.notEqual(domain.parentHash, ZeroHash);
-    assert.ok(domain.depth > 0);
+    assert.ok(!!domain.parent, `Domain ${domain.id} 'isWorld' is false, but 'parent' is undefined`);
+    assert.notEqual(domain.parentHash, ZeroHash,`Domain ${domain.id} 'isWorld' is false, but 'parentHash' is 0x0`);
+    assert.ok(domain.depth > 0,`Domain ${domain.id} 'isWorld' is false, but 'depth' is 0`);
   }
 }

--- a/src/utils/migration/zns-contract-data.ts
+++ b/src/utils/migration/zns-contract-data.ts
@@ -1,0 +1,52 @@
+import { znsNames } from "../../deploy/missions/contracts/names";
+import { IZNSContracts } from "../../deploy/campaign/types";
+import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+import { getZNSFromDB } from "./database";
+import {
+  ZNSAccessController__factory,
+  ZNSRegistry__factory,
+  MeowTokenMock__factory,
+  ZNSAddressResolver__factory,
+  ZNSCurvePricer__factory,
+  ZNSDomainToken__factory,
+  ZNSFixedPricer__factory,
+  ZNSRootRegistrar__factory,
+  ZNSSubRegistrar__factory,
+  ZNSTreasury__factory
+} from "../../../typechain/index";
+
+let znsCache : IZNSContracts | null = null;
+
+export const getZNS = async (signer : SignerWithAddress) => {
+  if (!znsCache || Object.values(znsCache).length < 10) {
+    const zns = await getZNSFromDB();
+
+    // Get each contract and manually connect to a factory.
+    // Using `getContractFactory()` returns an incorrect type of factory here
+    const acAddress = zns.find((contract) => contract.name === znsNames.accessController.contract);
+    const regAddress = zns.find((contract) => contract.name === znsNames.registry.contract);
+    const domainTokenAddress = zns.find((contract) => contract.name === znsNames.domainToken.contract);
+    const meowTokenAddress = zns.find((contract) => contract.name === znsNames.meowToken.contractMock); // contract on prod, contractMock on testnet
+    const addressResolverAddress = zns.find((contract) => contract.name === znsNames.addressResolver.contract);
+    const curvePricerAddress = zns.find((contract) => contract.name === znsNames.curvePricer.contract);
+    const treasuryAddress = zns.find((contract) => contract.name === znsNames.treasury.contract);
+    const rootRegistrarAddress = zns.find((contract) => contract.name === znsNames.rootRegistrar.contract);
+    const fixedPricerAddress = zns.find((contract) => contract.name === znsNames.fixedPricer.contract);
+    const subRegistrarAddress = zns.find((contract) => contract.name === znsNames.subRegistrar.contract);
+
+    znsCache = {
+      accessController: ZNSAccessController__factory.connect(acAddress!.address, signer),
+      registry: ZNSRegistry__factory.connect(regAddress!.address, signer),
+      domainToken: ZNSDomainToken__factory.connect(domainTokenAddress!.address, signer),
+      meowToken: MeowTokenMock__factory.connect(meowTokenAddress!.address, signer),
+      addressResolver: ZNSAddressResolver__factory.connect(addressResolverAddress!.address, signer),
+      curvePricer: ZNSCurvePricer__factory.connect(curvePricerAddress!.address, signer),
+      treasury: ZNSTreasury__factory.connect(treasuryAddress!.address, signer),
+      rootRegistrar: ZNSRootRegistrar__factory.connect(rootRegistrarAddress!.address, signer),
+      fixedPricer: ZNSFixedPricer__factory.connect(fixedPricerAddress!.address, signer),
+      subRegistrar: ZNSSubRegistrar__factory.connect(subRegistrarAddress!.address, signer),
+    }
+  }
+
+  return znsCache;
+};

--- a/src/utils/migration/zns-contract-data.ts
+++ b/src/utils/migration/zns-contract-data.ts
@@ -12,7 +12,7 @@ import {
   ZNSFixedPricer__factory,
   ZNSRootRegistrar__factory,
   ZNSSubRegistrar__factory,
-  ZNSTreasury__factory
+  ZNSTreasury__factory,
 } from "../../../typechain/index";
 
 let znsCache : IZNSContracts | null = null;
@@ -24,25 +24,25 @@ export const getZNS = async (
   if (!znsCache || Object.values(znsCache).length < 10) {
     const zns = await getZNSFromDB();
 
-    const meowTokenAddress = zns.find((contract) => { 
+    const meowTokenAddress = zns.find(contract => {
       if (env === "prod") {
         return contract.name === znsNames.meowToken.contract;
       } else {
-        contract.name === znsNames.meowToken.contractMock
+        contract.name === znsNames.meowToken.contractMock;
       }
     });
 
     // Get each contract and manually connect to a factory.
     // Using `getContractFactory()` returns an incorrect type of factory here
-    const acAddress = zns.find((contract) => contract.name === znsNames.accessController.contract);
-    const regAddress = zns.find((contract) => contract.name === znsNames.registry.contract);
-    const domainTokenAddress = zns.find((contract) => contract.name === znsNames.domainToken.contract);
-    const addressResolverAddress = zns.find((contract) => contract.name === znsNames.addressResolver.contract);
-    const curvePricerAddress = zns.find((contract) => contract.name === znsNames.curvePricer.contract);
-    const treasuryAddress = zns.find((contract) => contract.name === znsNames.treasury.contract);
-    const rootRegistrarAddress = zns.find((contract) => contract.name === znsNames.rootRegistrar.contract);
-    const fixedPricerAddress = zns.find((contract) => contract.name === znsNames.fixedPricer.contract);
-    const subRegistrarAddress = zns.find((contract) => contract.name === znsNames.subRegistrar.contract);
+    const acAddress = zns.find(contract => contract.name === znsNames.accessController.contract);
+    const regAddress = zns.find(contract => contract.name === znsNames.registry.contract);
+    const domainTokenAddress = zns.find(contract => contract.name === znsNames.domainToken.contract);
+    const addressResolverAddress = zns.find(contract => contract.name === znsNames.addressResolver.contract);
+    const curvePricerAddress = zns.find(contract => contract.name === znsNames.curvePricer.contract);
+    const treasuryAddress = zns.find(contract => contract.name === znsNames.treasury.contract);
+    const rootRegistrarAddress = zns.find(contract => contract.name === znsNames.rootRegistrar.contract);
+    const fixedPricerAddress = zns.find(contract => contract.name === znsNames.fixedPricer.contract);
+    const subRegistrarAddress = zns.find(contract => contract.name === znsNames.subRegistrar.contract);
 
     znsCache = {
       accessController: ZNSAccessController__factory.connect(acAddress!.address, signer),
@@ -55,7 +55,7 @@ export const getZNS = async (
       rootRegistrar: ZNSRootRegistrar__factory.connect(rootRegistrarAddress!.address, signer),
       fixedPricer: ZNSFixedPricer__factory.connect(fixedPricerAddress!.address, signer),
       subRegistrar: ZNSSubRegistrar__factory.connect(subRegistrarAddress!.address, signer),
-    }
+    };
   }
 
   return znsCache;

--- a/src/utils/migration/zns-contract-data.ts
+++ b/src/utils/migration/zns-contract-data.ts
@@ -17,16 +17,26 @@ import {
 
 let znsCache : IZNSContracts | null = null;
 
-export const getZNS = async (signer : SignerWithAddress) => {
+export const getZNS = async (
+  signer : SignerWithAddress,
+  env : string
+) => {
   if (!znsCache || Object.values(znsCache).length < 10) {
     const zns = await getZNSFromDB();
+
+    const meowTokenAddress = zns.find((contract) => { 
+      if (env === "prod") {
+        return contract.name === znsNames.meowToken.contract;
+      } else {
+        contract.name === znsNames.meowToken.contractMock
+      }
+    });
 
     // Get each contract and manually connect to a factory.
     // Using `getContractFactory()` returns an incorrect type of factory here
     const acAddress = zns.find((contract) => contract.name === znsNames.accessController.contract);
     const regAddress = zns.find((contract) => contract.name === znsNames.registry.contract);
     const domainTokenAddress = zns.find((contract) => contract.name === znsNames.domainToken.contract);
-    const meowTokenAddress = zns.find((contract) => contract.name === znsNames.meowToken.contractMock); // contract on prod, contractMock on testnet
     const addressResolverAddress = zns.find((contract) => contract.name === znsNames.addressResolver.contract);
     const curvePricerAddress = zns.find((contract) => contract.name === znsNames.curvePricer.contract);
     const treasuryAddress = zns.find((contract) => contract.name === znsNames.treasury.contract);

--- a/src/utils/migration/zns-contract-data.ts
+++ b/src/utils/migration/zns-contract-data.ts
@@ -45,16 +45,16 @@ export const getZNS = async (
     const subRegistrarAddress = zns.find(contract => contract.name === znsNames.subRegistrar.contract);
 
     znsCache = {
-      accessController: ZNSAccessController__factory.connect(acAddress!.address, signer),
-      registry: ZNSRegistry__factory.connect(regAddress!.address, signer),
-      domainToken: ZNSDomainToken__factory.connect(domainTokenAddress!.address, signer),
-      meowToken: MeowTokenMock__factory.connect(meowTokenAddress!.address, signer),
-      addressResolver: ZNSAddressResolver__factory.connect(addressResolverAddress!.address, signer),
-      curvePricer: ZNSCurvePricer__factory.connect(curvePricerAddress!.address, signer),
-      treasury: ZNSTreasury__factory.connect(treasuryAddress!.address, signer),
-      rootRegistrar: ZNSRootRegistrar__factory.connect(rootRegistrarAddress!.address, signer),
-      fixedPricer: ZNSFixedPricer__factory.connect(fixedPricerAddress!.address, signer),
-      subRegistrar: ZNSSubRegistrar__factory.connect(subRegistrarAddress!.address, signer),
+      accessController: ZNSAccessController__factory.connect(acAddress?.address, signer),
+      registry: ZNSRegistry__factory.connect(regAddress?.address, signer),
+      domainToken: ZNSDomainToken__factory.connect(domainTokenAddress?.address, signer),
+      meowToken: MeowTokenMock__factory.connect(meowTokenAddress?.address, signer),
+      addressResolver: ZNSAddressResolver__factory.connect(addressResolverAddress?.address, signer),
+      curvePricer: ZNSCurvePricer__factory.connect(curvePricerAddress?.address, signer),
+      treasury: ZNSTreasury__factory.connect(treasuryAddress?.address, signer),
+      rootRegistrar: ZNSRootRegistrar__factory.connect(rootRegistrarAddress?.address, signer),
+      fixedPricer: ZNSFixedPricer__factory.connect(fixedPricerAddress?.address, signer),
+      subRegistrar: ZNSSubRegistrar__factory.connect(subRegistrarAddress?.address, signer),
     };
   }
 

--- a/src/utils/migration/zns-contract-data.ts
+++ b/src/utils/migration/zns-contract-data.ts
@@ -1,5 +1,5 @@
 import { znsNames } from "../../deploy/missions/contracts/names";
-import { IZNSContracts } from "../../deploy/campaign/types";
+import { IZNSContracts } from "../../../test/helpers/types";
 import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 import { getZNSFromDB } from "./database";
 import {

--- a/test/helpers/types.ts
+++ b/test/helpers/types.ts
@@ -98,7 +98,7 @@ export interface IZNSContracts {
   rootRegistrar : ZNSRootRegistrar;
   fixedPricer : ZNSFixedPricer;
   subRegistrar : ZNSSubRegistrar;
-  zeroVaultAddress : string;
+  zeroVaultAddress ?: string;
 }
 
 export interface DeployZNSParams {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,25 @@
   resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz#d2a39395c587e092d77cbbc80acf956a54f38bf7"
   integrity sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q==
 
+"@apollo/client@^3.5.6":
+  version "3.13.6"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.13.6.tgz#64db62d74b1aa78bfff50d995b3473e9a8c70ab7"
+  integrity sha512-G6A8uNb13V/Tv4TJQOs5PnxuE5Rf5D2dMnBQcg9mng1Eo4YBecwFEJ0L022mraq/dLB0jD5tiAESOD2bTyJ6gg==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.1.1"
+    "@wry/caches" "^1.0.0"
+    "@wry/equality" "^0.5.6"
+    "@wry/trie" "^0.5.0"
+    graphql-tag "^2.12.6"
+    hoist-non-react-statics "^3.3.2"
+    optimism "^0.18.0"
+    prop-types "^15.7.2"
+    rehackt "^0.1.0"
+    symbol-observable "^4.0.0"
+    ts-invariant "^0.10.3"
+    tslib "^2.3.0"
+    zen-observable-ts "^1.2.5"
+
 "@aws-crypto/sha256-js@1.2.2":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz#02acd1a1fda92896fc5a28ec7c6e164644ea32fc"
@@ -585,6 +604,11 @@
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
+
+"@graphql-typed-document-node/core@^3.1.1":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.2.0.tgz#5f3d96ec6b2354ad6d8a28bf216a1d97b5426861"
+  integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
 
 "@humanwhocodes/config-array@^0.11.13":
   version "0.11.13"
@@ -1830,6 +1854,13 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/graphql@^14.5.0":
+  version "14.5.0"
+  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-14.5.0.tgz#a545fb3bc8013a3547cf2f07f5e13a33642b75d6"
+  integrity sha512-MOkzsEp1Jk5bXuAsHsUi6BVv0zCO+7/2PTiZMXWDSsMXvNU6w/PLMQT2vHn8hy2i0JqojPz1Sz6rsFjHtsU0lA==
+  dependencies:
+    graphql "*"
+
 "@types/http-cache-semantics@^4.0.2":
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz#b979ebad3919799c979b17c72621c0bc0a31c6c4"
@@ -2041,6 +2072,34 @@
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
+
+"@wry/caches@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@wry/caches/-/caches-1.0.1.tgz#8641fd3b6e09230b86ce8b93558d44cf1ece7e52"
+  integrity sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==
+  dependencies:
+    tslib "^2.3.0"
+
+"@wry/context@^0.7.0":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.7.4.tgz#e32d750fa075955c4ab2cfb8c48095e1d42d5990"
+  integrity sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==
+  dependencies:
+    tslib "^2.3.0"
+
+"@wry/equality@^0.5.6":
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.5.7.tgz#72ec1a73760943d439d56b7b1e9985aec5d497bb"
+  integrity sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==
+  dependencies:
+    tslib "^2.3.0"
+
+"@wry/trie@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@wry/trie/-/trie-0.5.0.tgz#11e783f3a53f6e4cd1d42d2d1323f5bc3fa99c94"
+  integrity sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==
+  dependencies:
+    tslib "^2.3.0"
 
 "@zero-tech/eslint-config-cpt@0.2.7":
   version "0.2.7"
@@ -4835,6 +4894,18 @@ graphemer@^1.4.0:
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
+graphql-tag@^2.12.6:
+  version "2.12.6"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.6.tgz#d441a569c1d2537ef10ca3d1633b48725329b5f1"
+  integrity sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==
+  dependencies:
+    tslib "^2.1.0"
+
+graphql@*:
+  version "16.10.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.10.0.tgz#24c01ae0af6b11ea87bf55694429198aaa8e220c"
+  integrity sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==
+
 handlebars@^4.0.1, handlebars@^4.7.7:
   version "4.7.8"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.8.tgz#41c42c18b1be2365439188c77c6afae71c0cd9e9"
@@ -5036,6 +5107,13 @@ hmac-drbg@^1.0.1:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
+
+hoist-non-react-statics@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
 
 hook-std@^3.0.0:
   version "3.0.0"
@@ -5633,7 +5711,7 @@ js-sha3@^0.5.7:
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.5.7.tgz#0d4ffd8002d5333aabaf4a23eed2f6374c9f28e7"
   integrity sha512-GII20kjaPX0zJ8wzkTbNDYMY7msuZcTWk8S5UOh6806Jq/wz1J8/bnr8uGU0DAUmYDjj2Mr4X1cW8v/GLYnR+g==
 
-js-tokens@^4.0.0:
+"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
@@ -6121,6 +6199,13 @@ logform@^2.3.2, logform@^2.4.0:
     ms "^2.1.1"
     safe-stable-stringify "^2.3.1"
     triple-beam "^1.3.0"
+
+loose-envify@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
 
 loupe@^2.3.6:
   version "2.3.7"
@@ -6997,7 +7082,7 @@ number-to-bn@1.7.0:
     bn.js "4.11.6"
     strip-hex-prefix "1.0.0"
 
-object-assign@^4.1.0:
+object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
@@ -7100,6 +7185,16 @@ open@^8.4.0:
     define-lazy-prop "^2.0.0"
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
+
+optimism@^0.18.0:
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.18.1.tgz#5cf16847921413dbb0ac809907370388b9c6335f"
+  integrity sha512-mLXNwWPa9dgFyDqkNi54sjDyNJ9/fTI6WGBLgnXku1vdKY/jovHfZT5r+aiVeFFLOz+foPNOm5YJ4mqgld2GBQ==
+  dependencies:
+    "@wry/caches" "^1.0.0"
+    "@wry/context" "^0.7.0"
+    "@wry/trie" "^0.5.0"
+    tslib "^2.3.0"
 
 optionator@^0.8.1:
   version "0.8.3"
@@ -7563,6 +7658,15 @@ promzard@^1.0.0:
   dependencies:
     read "^2.0.0"
 
+prop-types@^15.7.2:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
+  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.13.1"
+
 proper-lockfile@^4.1.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/proper-lockfile/-/proper-lockfile-4.1.2.tgz#c8b9de2af6b2f1601067f98e01ac66baa223141f"
@@ -7645,6 +7749,16 @@ rc@1.2.8, rc@^1.2.8:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-is@^16.13.1, react-is@^16.7.0:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react@^19.1.0:
+  version "19.1.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-19.1.0.tgz#926864b6c48da7627f004795d6cce50e90793b75"
+  integrity sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==
 
 read-cmd-shim@^4.0.0:
   version "4.0.0"
@@ -7832,6 +7946,11 @@ registry-url@^6.0.0:
   integrity sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==
   dependencies:
     rc "1.2.8"
+
+rehackt@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/rehackt/-/rehackt-0.1.0.tgz#a7c5e289c87345f70da8728a7eb878e5d03c696b"
+  integrity sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==
 
 req-cwd@^2.0.0:
   version "2.0.0"
@@ -8711,6 +8830,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+symbol-observable@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-4.0.0.tgz#5b425f192279e87f2f9b937ac8540d1984b39205"
+  integrity sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==
+
 sync-request@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/sync-request/-/sync-request-6.1.0.tgz#e96217565b5e50bbffe179868ba75532fb597e68"
@@ -8909,6 +9033,13 @@ ts-essentials@^7.0.1:
   resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-7.0.3.tgz#686fd155a02133eedcc5362dc8b5056cde3e5a38"
   integrity sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==
 
+ts-invariant@^0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.10.3.tgz#3e048ff96e91459ffca01304dbc7f61c1f642f6c"
+  integrity sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==
+  dependencies:
+    tslib "^2.1.0"
+
 ts-node@10.9.1:
   version "10.9.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
@@ -8966,6 +9097,11 @@ tslib@^1.11.1, tslib@^1.8.1, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.1.0, tslib@^2.3.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tslib@^2.3.1, tslib@^2.5.0:
   version "2.6.2"
@@ -9629,6 +9765,18 @@ yocto-queue@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
   integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
+
+zen-observable-ts@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz#6c6d9ea3d3a842812c6e9519209365a122ba8b58"
+  integrity sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==
+  dependencies:
+    zen-observable "0.8.15"
+
+zen-observable@0.8.15:
+  version "0.8.15"
+  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
+  integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
 
 zksync-web3@^0.14.3:
   version "0.14.4"


### PR DESCRIPTION
Grab data from subgraph and validate against onchain data through Ethers.

The migration hasn't been defined but all solutions will use this as a first step. The registration script hasn't been altered since it's original inception as a result as it may be usable later.