### PR TITLE
Update query to also get payment data in validation

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -12,20 +12,24 @@ SEPOLIA_RPC_URL=
 # ENV vars for MongoDB, for local development you can use below
 MONGO_DB_URI="mongodb://localhost:27018"
 MONGO_DB_NAME="zns-campaign"
+
 # Optional params for Mongo Client class specifically
 MONGO_DB_CLIENT_OPTS=
+
 # This is crucial based on the DB behaviour you want. MongoAdapter will create a new DB version if this is NOT passed
 # and it will use existing version if specified. If you want to deploy from scratch, do not supply and the previous
 # versioned data will be wiped out.
 # If you wish to save the previous data and write a new version on top, look at the next ENV var.
 MONGO_DB_VERSION=
+
 # This is crucial to saving the data written in previous DB (DEPLOYED) version.
 # If this is not passed or passed as "false", previous DB data will be wiped out.
 # If you want to save the previous contract data in DB, set this to "true"!
 ARCHIVE_PREVIOUS_DB_VERSION="true" | "false"
 
 # ENV vars for Logger
-LOG_LEVEL="debug" | "info" | "warn" | "error
+LOG_LEVEL="debug" | "info" | "warn" | "error"
+
 # Removes logger output and does not write to file as well
 SILENT_LOGGER="false" | "true"
 
@@ -33,6 +37,7 @@ SILENT_LOGGER="false" | "true"
 # true = we deploy the mock
 # false = we use a hard coded address and pull data from chain
 MOCK_MEOW_TOKEN=
+
 # Address of the MEOW Token deployed to the network PRIOR to running Campaign or any other EXISTING token
 # This is only used if MOCK_MEOW_TOKEN is set to false (`test` and `prod` environments)
 STAKING_TOKEN_ADDRESS=
@@ -42,7 +47,6 @@ MAX_PRICE=
 MIN_PRICE=
 MAX_LENGTH=
 BASE_LENGTH=
-
 DECIMALS=
 PRECISION=
 PROTOCOL_FEE_PERC=
@@ -65,6 +69,7 @@ ADMIN_ADDRESSES=
 MONITOR_CONTRACTS="false"
 VERIFY_CONTRACTS="false"
 
+# For using OpenZeppelin Defender for deployment
 DEFENDER_KEY=
 DEFENDER_SECRET=
 RELAYER_KEY=
@@ -81,3 +86,8 @@ TENDERLY_ACCOUNT_ID="zer0-os"
 # Below are used only for the `deploy:devnet` script (for testing new logic) NOT RELATED TO THE DEPLOY CAMPAIGN !
 TENDERLY_DEVNET_TEMPLATE="zns-devnet"
 DEVNET_RPC_URL=
+
+# If executing the migration scripts, you must also specify
+# the below to specify a different database to write data too
+MONGO_DB_URI_WRITE=
+MONGO_DB_NAME_WRITE=

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -103,7 +103,7 @@ const config : HardhatUserConfig = {
       url: `${process.env.MAINNET_RPC_URL}`,
       accounts: [
         // Read only
-        `${process.env.TESTNET_PRIVATE_KEY}`, // Commented for CI, uncomment this when using Mainnet
+        // `${process.env.TESTNET_PRIVATE_KEY}`, // Commented for CI, uncomment this when using Mainnet
       ],
       gasPrice: 80000000000,
     },

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -103,7 +103,7 @@ const config : HardhatUserConfig = {
       url: `${process.env.MAINNET_RPC_URL}`,
       accounts: [
         // Read only
-        // `${process.env.TESTNET_PRIVATE_KEY}`, // Commented for CI, uncomment this when using Mainnet
+        `${process.env.TESTNET_PRIVATE_KEY}`, // Commented for CI, uncomment this when using Mainnet
       ],
       gasPrice: 80000000000,
     },

--- a/src/utils/migration/01_validation.ts
+++ b/src/utils/migration/01_validation.ts
@@ -31,6 +31,12 @@ const main = async () => {
   const roots = rootDomainObjects.map(d => d as Domain);
   const subs = subdomainObjects.map(d => d as Domain);
 
+  const dbName = process.env.MONGO_DB_NAME_WRITE;
+  if (!dbName) throw Error("No DB name given");
+
+  const uri = process.env.MONGO_DB_URI_WRITE;
+  if (!uri) throw Error("No connection string given");
+
   // Can iterate all at once for simplicity
   let index = 0;
   for(const domain of [...roots, ...subs]) {
@@ -51,12 +57,6 @@ const main = async () => {
   }
 
   // Connect to database collection and write user domain data to DB
-  const dbName = process.env.MONGO_DB_NAME_WRITE;
-  if (!dbName) throw Error("No DB name given");
-
-  const uri = process.env.MONGO_DB_URI_WRITE;
-  if (!uri) throw Error("No connection string given");
-
   const client = (await getDBAdapter(uri)).db(dbName);
 
   // To avoid duplicate data, we clear the DB before any inserts

--- a/src/utils/migration/01_validation.ts
+++ b/src/utils/migration/01_validation.ts
@@ -32,7 +32,7 @@ const main = async () => {
   const subs = subdomainObjects.map(d => d as Domain);
 
   const dbName = process.env.MONGO_DB_NAME_WRITE;
-  if (!dbName) throw Error("No DB name given");
+  if (!dbName) throw Error("Missing MONGO_DB_NAME_WRITE environment variable");
 
   const uri = process.env.MONGO_DB_URI_WRITE;
   if (!uri) throw Error("No connection string given");

--- a/src/utils/migration/subgraph/queries.ts
+++ b/src/utils/migration/subgraph/queries.ts
@@ -98,6 +98,7 @@ export const getDomains = gql`
         id
         beneficiaryAddress
         paymentToken {
+          id
           name
           symbol
         }

--- a/src/utils/migration/subgraph/queries.ts
+++ b/src/utils/migration/subgraph/queries.ts
@@ -97,6 +97,10 @@ export const getDomains = gql`
       treasury {
         id
         beneficiaryAddress
+        paymentToken {
+          name
+          symbol
+        }
       }
       creationBlock
       creationTimestamp


### PR DESCRIPTION
Update the subgraph query to also read `paymentToken` properties for the query that is run as part of validation. Also move the env var checks to be ahead of the `validation` loop that can take a long time only to fail if the vars are not set properly