### PR TITLE
Fix - A Single token owner can block all transfers in batch

### DIFF
--- a/src/deploy/campaign/types.ts
+++ b/src/deploy/campaign/types.ts
@@ -56,20 +56,6 @@ export type ZNSContract =
   ZNSSubRegistrar;
 
 export interface IZNSContracts extends IContractState<ZNSContract> {
-  accessController : ZNSAccessController;
-  registry : ZNSRegistry;
-  domainToken : ZNSDomainToken;
-  meowToken : ERC20Mock;
-  addressResolver : ZNSAddressResolver;
-  stringResolver : ZNSStringResolver;
-  curvePricer : ZNSCurvePricer;
-  treasury : ZNSTreasury;
-  rootRegistrar : ZNSRootRegistrar;
-  fixedPricer : ZNSFixedPricer;
-  subRegistrar : ZNSSubRegistrar;
-}
-
-export interface IZNSContractsCache {
   meowToken : ERC20Mock;
   accessController : ZNSAccessController;
   registry : ZNSRegistry;

--- a/src/utils/migration/constants.ts
+++ b/src/utils/migration/constants.ts
@@ -3,6 +3,7 @@ import { ZNSDomainToken__factory, ZNSRootRegistrar__factory, ZNSSubRegistrar__fa
 export const ROOT_COLL_NAME = process.env.MONGO_DB_ROOT_COLL_NAME || "root-domains";
 export const SUB_COLL_NAME = process.env.MONGO_DB_SUB_COLL_NAME || "subdomains";
 export const INVALID_COLL_NAME = process.env.MONGO_DB_INVALID_COLL_NAME || "invalid-domains";
+export const INVALID_TX_COLL_NAME = process.env.MONGO_DB_INVALID_COLL_NAME || "invalid-transactions";
 
 export const ROOT_DOMAIN_BULK_SELECTOR = ZNSRootRegistrar__factory.createInterface().getFunction(
   "registerRootDomainBulk"

--- a/src/utils/migration/helpers.ts
+++ b/src/utils/migration/helpers.ts
@@ -315,21 +315,17 @@ export const createTransfers = async (
       operation: OperationType.Call,
     };
 
-    const bytecode = await hre.ethers.provider.getCode(domain.domainToken.owner.id);
-
-    if (bytecode.length > 2) {
-      try {
-        // If destination address is EOA or contract that implements `onERC721Received`
-        // this should pass. Otherwise, we mark the transfer as a failure to avoid failing
-        // the entire batch later
-        await domainToken["safeTransferFrom(address,address,uint256)"].estimateGas(
-          safeAddress,
-          domain.domainToken.owner.id,
-          domain.tokenId
-        );
-      } catch (e) {
-        failedTransfers.push(domain);
-      }
+    try {
+      // If destination address is EOA or contract that implements `onERC721Received`
+      // this should pass. Otherwise, we mark the transfer as a failure to avoid failing
+      // the entire batch later
+      await domainToken["safeTransferFrom(address,address,uint256)"].estimateGas(
+        safeAddress,
+        domain.domainToken.owner.id,
+        domain.tokenId
+      );
+    } catch (e) {
+      failedTransfers.push(domain);
     }
 
     if (!domain.isRevoked) {

--- a/src/utils/migration/helpers.ts
+++ b/src/utils/migration/helpers.ts
@@ -7,12 +7,19 @@ import {
   ISubdomainRegistrationArgs,
   RootRegistrationArgsBatches,
   SubRegistrationArgsBatches,
+  Tx,
 } from "./types";
-import { ZNSDomainToken__factory, ZNSRootRegistrar__factory, ZNSSubRegistrar__factory } from "../../../typechain";
+import {
+  ZNSDomainToken,
+  ZNSDomainToken__factory,
+  ZNSRootRegistrar__factory,
+  ZNSSubRegistrar__factory,
+} from "../../../typechain";
 import { SUBDOMAIN_BULK_SELECTOR } from "./constants";
 import { getZnsLogger } from "../../deploy/get-logger";
 import { SafeKit } from "./safeKit";
 import { OperationType } from "@safe-global/types-kit";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 /**
  * Create and propose batch transactions to the Safe for domain registrations
@@ -274,16 +281,18 @@ export const LogExecution = (target : any, propertyKey : string, descriptor : Pr
 /**
  * Create transfer transactions for domain tokens to their respective owners
  *
- * @param to The contract address to send transfer transactions to
+ * @param domainToken The contract to send the tx to
  * @param domains Array of domains to create transfers for
  * @returns Array of transfer transaction objects for Safe execution
  * @throws {Error} When Safe address is not configured
  */
-export const createTransfers = (
-  to : string,
+export const createTransfers = async (
+  hre : HardhatRuntimeEnvironment,
+  domainToken : ZNSDomainToken,
   domains : Array<Domain>,
-) => {
-  const transfers = [];
+) : Promise<[Array<Tx>, Array<Domain>]> => {
+  const transfers : Array<Tx> = [];
+  const failedTransfers : Array<Domain> = [];
 
   // Get safe address being used
   const safeAddress = process.env.SAFE_ADDRESS;
@@ -298,18 +307,38 @@ export const createTransfers = (
         [ safeAddress, domain.domainToken.owner.id, domain.tokenId ]
       );
 
-      // The `to` address must be the contract the multisig will call,
-      // not the multisig itself
-      transfers.push({
-        to,
+      const tx : Tx = {
+        to: await domainToken.getAddress(),
         value: "0",
         data: transferEncoding,
         operation: OperationType.Call,
-      });
+      };
+
+      const bytecode = await hre.ethers.provider.getCode(domain.domainToken.owner.id);
+
+      if (bytecode.length > 2) {
+        console.log("address is contract, reading...");
+        try {
+          // If destination address is EOA or contract that implements `onERC721Received`
+          // this should pass. Otherwise, we mark the transfer as a failure to avoid failing
+          // the entire batch later
+          await domainToken["safeTransferFrom(address,address,uint256)"].estimateGas(
+            safeAddress,
+            domain.domainToken.owner.id,
+            domain.tokenId
+          );
+        } catch (e) {
+          failedTransfers.push(domain);
+        }
+      }
+
+      // The `to` address must be the contract the multisig will call,
+      // not the multisig itself
+      transfers.push(tx);
     }
   }
 
-  return transfers;
+  return [ transfers, failedTransfers ];
 };
 
 export const getSubdomainParentHash = (domain : Domain) => {

--- a/src/utils/migration/register-bulk-safe-json.ts
+++ b/src/utils/migration/register-bulk-safe-json.ts
@@ -3,7 +3,7 @@ import { ROOT_COLL_NAME, SUB_COLL_NAME } from "./constants";
 import { Domain, SafeBatch, SafeTx } from "./types";
 import { Addressable, ZeroAddress, ZeroHash } from "ethers";
 import { connectToDb } from "./helpers";
-import { IZNSContractsCache } from "../../deploy/campaign/types";
+import { IZNSContracts } from "../../deploy/campaign/types";
 import { getZNS } from "./zns-contract-data";
 import { ZNSDomainToken__factory, ZNSRootRegistrar__factory, ZNSSubRegistrar__factory } from "../../../typechain";
 import * as fs from "fs";
@@ -97,7 +97,7 @@ const main = async () => {
 
 const createBatches = (
   domains : Array<Domain>,
-  zns : IZNSContractsCache,
+  zns : IZNSContracts,
   outputFile : string,
   rootDomains  = false,
   sliceSize : number = Number(process.env.DOMAIN_SLICE) || 50

--- a/src/utils/migration/types.ts
+++ b/src/utils/migration/types.ts
@@ -88,9 +88,9 @@ export interface SafeTxContractMethod {
 }
 
 export interface Tx {
-  to : string; // | Addressable;
+  to : string;
   value : string;
-  data : string; // TODO why this | null
+  data : string;
   operation : OperationType;
 }
 
@@ -109,14 +109,14 @@ export interface SafeTx {
 
 export interface SafeBatch {
   version : string; // 1.0
-  chainId : string; // 9369
+  chainId : string;
   createdAt : number; // timestamp
   meta ?: {
     name : string;
     description : string;
     txBuilderVersion : string; // 1.18.0
     createdFromSafeAddress : string; // 0x...
-    createdFromOwnerAddress : string; // 0x
+    createdFromOwnerAddress : string; // 0x...
     checksum : string;
   };
   transactions : Array<SafeTx>;

--- a/src/utils/migration/zns-contract-data.ts
+++ b/src/utils/migration/zns-contract-data.ts
@@ -14,13 +14,13 @@ import {
   ERC20Mock__factory,
   ZNSStringResolver__factory,
 } from "../../../typechain/index";
-import { IZNSContractsCache } from "../../deploy/campaign/types";
+import { IZNSContracts } from "../../deploy/campaign/types";
 
-let znsCache : IZNSContractsCache | null = null;
+let znsCache : IZNSContracts | null = null;
 
 export const getZNS = async (
   signer : SignerWithAddress,
-) : Promise<IZNSContractsCache> => {
+) : Promise<IZNSContracts> => {
   if (!znsCache || Object.values(znsCache).length < 10) {
     const zns = await getZNSFromDB();
 


### PR DESCRIPTION
Address the audit issue created by  the possibility of `transfers` beings sent to contracts that may not implement `onERC721Received`, which would cause a failing tx in the batch. As batches are executed by the Safe in a single tx, this would fail the entire batch not just this transactions.

To address this, we first get the bytecode for every potential transfer and then check the length. EOAs will have length of 2, just of `0x` but contracts will have more. We could additionally try to find out of the contract supports `onERC721Received` with something like `supportsInterface` however this isn't reliable and we've agreed it's enough to solve the problem by flagging any non-EOA transfer recipient instead.

 - [x] A Single token owner can block all transfers in batch